### PR TITLE
make AtomicWrites transactional #12

### DIFF
--- a/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBHelper.scala
+++ b/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBHelper.scala
@@ -100,6 +100,18 @@ trait DynamoDBHelper {
     def desc(aws: DescribeTableRequest): String = s"DescribeTableRequest(${aws.getTableName})"
   }
 
+  implicit object QueryDescribe extends Describe[QueryRequest] {
+    def desc(aws: QueryRequest): String = s"QueryRequest(${aws.getExpressionAttributeValues})"
+  }
+
+  implicit object PutItemDescribe extends Describe[PutItemRequest] {
+    def desc(aws: PutItemRequest): String = s"PutItemRequest(${aws.getItem.get(Key)})"
+  }
+
+  implicit object DeleteDescribe extends Describe[DeleteItemRequest] {
+    def desc(aws: DeleteItemRequest): String = s"DeleteItemRequest(${aws.getKey})"
+  }
+
   def listTables(aws: ListTablesRequest): Future[ListTablesResult] =
     send[ListTablesRequest, ListTablesResult](aws, dynamoDB.listTablesAsync(aws, _))
 

--- a/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBJournal.scala
+++ b/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBJournal.scala
@@ -166,14 +166,6 @@ class DynamoDBJournal(config: Config) extends AsyncWriteJournal with DynamoDBRec
     case SetDBHelperReporter(ref) => dynamo.setReporter(ref)
   }
 
-  def S(value: String): AttributeValue = new AttributeValue().withS(value)
-
-  def N(value: Long): AttributeValue = new AttributeValue().withN(value.toString)
-  def N(value: String): AttributeValue = new AttributeValue().withN(value)
-  val Naught = N(0)
-
-  def B(value: Array[Byte]): AttributeValue = new AttributeValue().withB(ByteBuffer.wrap(value))
-
   def keyLength(persistenceId: String, sequenceNr: Long): Int =
     persistenceId.length + JournalName.length + KeyPayloadOverhead
 

--- a/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBJournalConfig.scala
+++ b/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBJournalConfig.scala
@@ -81,5 +81,8 @@ class DynamoDBJournalConfig(c: Config) {
     ",SequenceShards:" + SequenceShards +
     ",ReplayParallelism" + ReplayParallelism +
     ",Tracing:" + Tracing +
+    ",MaxBatchGet:" + MaxBatchGet +
+    ",MaxBatchWrite:" + MaxBatchWrite +
+    ",MaxItemSize:" + MaxItemSize +
     ",client.config:" + client
 }

--- a/src/main/scala/akka/persistence/dynamodb/journal/package.scala
+++ b/src/main/scala/akka/persistence/dynamodb/journal/package.scala
@@ -15,6 +15,7 @@ import java.util.concurrent.{ ThreadPoolExecutor, LinkedBlockingQueue, TimeUnit 
 import scala.collection.generic.CanBuildFrom
 import java.util.concurrent.Executors
 import java.util.Collections
+import java.nio.ByteBuffer
 
 package object journal {
 
@@ -26,6 +27,8 @@ package object journal {
   val Sort = "num"
   val Payload = "pay"
   val SequenceNr = "seq"
+  val AtomIndex = "idx"
+  val AtomEnd = "cnt"
 
   val KeyPayloadOverhead = 26 // including fixed parts of partition key and 36 bytes fudge factor
 
@@ -40,6 +43,14 @@ package object journal {
       new AttributeDefinition().withAttributeName(Key).withAttributeType("S"),
       new AttributeDefinition().withAttributeName(Sort).withAttributeType("N")
     )
+
+  def S(value: String): AttributeValue = new AttributeValue().withS(value)
+
+  def N(value: Long): AttributeValue = new AttributeValue().withN(value.toString)
+  def N(value: String): AttributeValue = new AttributeValue().withN(value)
+  val Naught = N(0)
+
+  def B(value: Array[Byte]): AttributeValue = new AttributeValue().withB(ByteBuffer.wrap(value))
 
   def lift[T](f: Future[T]): Future[Try[T]] = {
     val p = Promise[Try[T]]

--- a/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBIntegrationLoadSpec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBIntegrationLoadSpec.scala
@@ -279,7 +279,7 @@ class DynamoDBIntegrationLoadSpec
       subscribeToRangeDeletion(deleteProbe)
       val processorAtomic = system.actorOf(Props(classOf[ProcessorAtomic], persistenceId, self))
 
-      processorAtomic ! List("a-1", "a-2", "a-3", "a-4", "a-5", "a-6")
+      List("a-1", "a-2", "a-3", "a-4", "a-5", "a-6") foreach (processorAtomic ! List(_))
       1L to 6L foreach { i =>
         expectMsgAllOf(s"a-${i}", i, false)
       }

--- a/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBUtils.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBUtils.scala
@@ -49,5 +49,11 @@ trait DynamoDBUtils {
   private val seqNr = Iterator from 1
   def persistenceId: String = ???
 
-  def persistentRepr(msg: Any) = PersistentRepr(msg, sequenceNr = seqNr.next(), persistenceId = persistenceId, writerUuid = writerUuid)
+  var generatedMessages: Vector[PersistentRepr] = Vector(null) // we start counting at 1
+
+  def persistentRepr(msg: Any) = {
+    val ret = PersistentRepr(msg, sequenceNr = seqNr.next(), persistenceId = persistenceId, writerUuid = writerUuid)
+    generatedMessages :+= ret
+    ret
+  }
 }

--- a/src/test/scala/akka/persistence/dynamodb/journal/RecoveryConsistencySpec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/RecoveryConsistencySpec.scala
@@ -11,6 +11,8 @@ import akka.persistence._
 import akka.persistence.JournalProtocol._
 import akka.testkit._
 import akka.persistence.journal.AsyncWriteTarget.ReplaySuccess
+import com.amazonaws.services.dynamodbv2.model._
+import java.util.{ HashMap => JHMap }
 
 class RecoveryConsistencySpec extends TestKit(ActorSystem("FailureReportingSpec"))
     with ImplicitSender
@@ -30,22 +32,54 @@ class RecoveryConsistencySpec extends TestKit(ActorSystem("FailureReportingSpec"
   override val persistenceId = "RecoveryConsistencySpec"
   lazy val journal = Persistence(system).journalFor("")
 
+  import settings._
+
   "DynamoDB Journal (Recovery)" must {
 
-    val N = 50
-    val M = 20
-    val writes = (1 to M).map(i => AtomicWrite(persistentRepr(f"a-$i%04d")))
+    val repetitions = 1
+    val messages = 20
+    val writes = (1 to messages).map(i => AtomicWrite(persistentRepr(f"a-$i%04d")))
     val probe = TestProbe()
 
-    for (i <- 1 to N) s"not return intermediate values for the highest sequence number ($i of $N)" in {
+    for (i <- 1 to repetitions) s"not return intermediate values for the highest sequence number ($i of $repetitions)" in {
       journal ! Purge(persistenceId, testActor)
       expectMsg(Purged(persistenceId))
       journal ! WriteMessages(writes, testActor, 1)
       journal ! ReplayMessages(1, 0, Long.MaxValue, persistenceId, probe.ref)
       expectMsg(WriteMessagesSuccessful)
-      (1 to M) foreach (_ => expectMsgType[WriteMessageSuccess])
-      probe.expectMsg(RecoverySuccess(M))
+      (1 to messages) foreach (i => expectMsgType[WriteMessageSuccess].persistent.sequenceNr should ===(i))
+      probe.expectMsg(RecoverySuccess(messages))
     }
 
+    "only replay completely persisted AtomicWrites" in {
+      val more =
+        AtomicWrite((1 to 3).map(i => persistentRepr(f"b-$i"))) :: // hole in the middle
+          AtomicWrite((4 to 6).map(i => persistentRepr(f"b-$i"))) :: // hole in the beginning
+          AtomicWrite((7 to 9).map(i => persistentRepr(f"b-$i"))) :: // no hole
+          AtomicWrite((10 to 12).map(i => persistentRepr(f"b-$i"))) :: // hole in the end
+          AtomicWrite((13 to 15).map(i => persistentRepr(f"b-$i"))) :: // hole in the end
+          AtomicWrite(persistentRepr("c")) ::
+          Nil
+      journal ! WriteMessages(more, testActor, 1)
+      expectMsg(WriteMessagesSuccessful)
+      (messages + 1 to messages + 16) foreach (i => expectMsg(WriteMessageSuccess(generatedMessages(i), 1)))
+
+      Seq(2, 4, 12, 15) foreach (i => delete(messages + i))
+
+      journal ! ReplayMessages(0, Long.MaxValue, Long.MaxValue, persistenceId, testActor)
+      for {
+        i <- 1 to (messages + 16)
+        if (i <= messages || (i >= (messages + 7) && i <= (messages + 9)) || i == (messages + 16))
+      } expectMsg(ReplayedMessage(generatedMessages(i)))
+      expectMsg(RecoverySuccess(messages + 16))
+    }
+
+  }
+
+  private def delete(num: Long) = {
+    val key: Item = new JHMap
+    key.put(Key, S(s"$JournalName-P-$persistenceId-${num / 100}"))
+    key.put(Sort, N(num % 100))
+    client.deleteItem(new DeleteItemRequest().withTableName(JournalTable).withKey(key)).futureValue
   }
 }

--- a/src/test/scala/akka/persistence/dynamodb/journal/RecoveryConsistencySpec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/RecoveryConsistencySpec.scala
@@ -36,7 +36,7 @@ class RecoveryConsistencySpec extends TestKit(ActorSystem("FailureReportingSpec"
 
   "DynamoDB Journal (Recovery)" must {
 
-    val repetitions = 1
+    val repetitions = 50
     val messages = 20
     val writes = (1 to messages).map(i => AtomicWrite(persistentRepr(f"a-$i%04d")))
     val probe = TestProbe()


### PR DESCRIPTION
Currently the TCK demands that a partial write can be replayed at the
upper limit of the replay range, so this is implemented.

fixes #12
