### PR TITLE
Library updates and Scala updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: scala
 jdk:
   - oraclejdk8
 scala:
-  - "2.11.7"
+  - "2.11.8"
+  - "2.12.1"
 before_install:
   - mkdir /tmp/dynamodb
   - wget -O - http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_latest.tar.gz | tar xzC /tmp/dynamodb

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A replicated [Akka Persistence](http://doc.akka.io/docs/akka/2.4.0/scala/persist
 
 **Please note that this module does neither include a snapshot-store plugin nor an Akka Persistence Query plugin.**
 
-Scala: `2.11.x` or `2.12.0-M3`  Akka: `2.4.2`  Java: `8+`
+Scala: `2.11.x` or `2.12.1`  Akka: `2.4.14`  Java: `8+`
 
 [![Join the chat at https://gitter.im/akka/akka-persistence-dynamodb](https://badges.gitter.im/akka/akka-persistence-dynamodb.svg)](https://gitter.im/akka/akka-persistence-dynamodb?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/akka/akka-persistence-dynamodb.svg?branch=master)](https://travis-ci.org/akka/akka-persistence-dynamodb)
@@ -26,11 +26,11 @@ This plugin is published to the Maven Central repository with the following name
 
 or for sbt users:
 
-~~~
+```sbt
 libraryDependencies += "com.typesafe.akka" % "akka-persistence-dynamodb_2.11" % "1.0.0"
-~~~
+```
 
-Substitute the `_2.11` suffix by `_2.12.0-M3` when using Scala version 2.12.0-M3. This plugin requires Java 8 (just as Akka itself).
+Substitute the `_2.11` suffix by `_2.12` when using Scala version 2.12.1 or greater. This plugin requires Java 8 (just as Akka itself).
 
 Configuration
 -------------
@@ -60,14 +60,14 @@ Storage Semantics
 
 DynamoDB only offers consistency guarantees for a single storage item—which corresponds to one event in the case of this Akka Persistence plugin. This means that any single event is either written to the journal (and thereby visible to later replays) or it is not. This plugin supports atomic multi-event batches nevertheless, by marking the contained events such that partial replay can be avoided (see the `idx` and `cnt` attributes in the storage format description below). Consider the following actions of a PersistentActor:
 
-~~~scala
+```scala
 val events = List(<some events>)
 if (atomic) {
   persistAll(events)(handler)
 else {
   for (event <- events) persist(event)(handler)
 }
-~~~
+```
 
 In the first case a recovery will only ever see all of the events or none of them. This is also true if recovery is requested with an upper limit on the sequence number to be recovered to or a limit on the number of events to be replayed; the event count limit is applied before removing incomplete batch writes which means that the actual count of events received at the actor may be lower than the requested limit even if further events are available.
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,21 +1,22 @@
 name := "akka-persistence-dynamodb"
 
-scalaVersion       := "2.11.7"
-crossScalaVersions := Seq("2.11.7", "2.12.0-M3")
+scalaVersion       := "2.11.8"
+crossScalaVersions := Seq("2.11.8", "2.12.1")
 crossVersion       := CrossVersion.binary
 
-val akkaVersion = "2.4.2"
+val akkaVersion = "2.4.14"
+val amzVersion = "1.11.66"
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-java-sdk-core" % "1.10.50",
-  "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.10.50",
-  "com.typesafe.akka" %% "akka-persistence" % akkaVersion,
-  "com.typesafe.akka" %% "akka-stream" % akkaVersion,
-  "com.typesafe.akka" %% "akka-persistence-tck" % akkaVersion % "test",
-  "com.typesafe.akka" %% "akka-testkit" % akkaVersion % "test",
-  "org.scalatest" %% "scalatest" % "2.1.7" % "test",
-  "commons-io" % "commons-io" % "2.4" % "test",
-  "org.hdrhistogram" % "HdrHistogram" % "2.1.8" % "test"
+  "com.amazonaws"       % "aws-java-sdk-core"       % amzVersion,
+  "com.amazonaws"       % "aws-java-sdk-dynamodb"   % amzVersion,
+  "com.typesafe.akka"   %% "akka-persistence"       % akkaVersion,
+  "com.typesafe.akka"   %% "akka-stream"            % akkaVersion,
+  "com.typesafe.akka"   %% "akka-persistence-tck"   % akkaVersion   % "test",
+  "com.typesafe.akka"   %% "akka-testkit"           % akkaVersion   % "test",
+  "org.scalatest"       %% "scalatest"              % "3.0.1"       % "test",
+  "commons-io"          % "commons-io"              % "2.4"         % "test",
+  "org.hdrhistogram"    % "HdrHistogram"            % "2.1.8"       % "test"
 )
 
 parallelExecution in Test := false

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.12

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.1")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 


### PR DESCRIPTION
### Language updates
- Scala 2.11.7 to 2.11.8 plus 2.12.1 cross-builds
- Travis CI builds have been updated from 2.11.7 to run tests for both 2.11.8 and 2.12.1

### Library updates
- Akka 2.4.2 to 2.4.14
- Amazon Java SDK 1.10.50 to 1.11.66
- ScalaTest 2.1.7 to 3.0.1

### SBT updates
- SBT 0.13.9 to 0.13.12

### SBT compiler plugin updates
- SBT-release 1.0.1 to 1.0.3
- SBT-pgp 0.8.1 to 0.8.3
