### PR TITLE
Switch to Akka HTTP based AWS connector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: scala
 jdk:
   - oraclejdk8
 scala:
-  - "2.11.8"
   - "2.12.1"
+  - "2.11.8"
 before_install:
   - mkdir /tmp/dynamodb
   - wget -O - http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_latest.tar.gz | tar xzC /tmp/dynamodb

--- a/build.sbt
+++ b/build.sbt
@@ -8,15 +8,15 @@ val akkaVersion = "2.4.14"
 val amzVersion = "1.11.66"
 
 libraryDependencies ++= Seq(
-  "com.amazonaws"       % "aws-java-sdk-core"       % amzVersion,
-  "com.amazonaws"       % "aws-java-sdk-dynamodb"   % amzVersion,
-  "com.typesafe.akka"   %% "akka-persistence"       % akkaVersion,
-  "com.typesafe.akka"   %% "akka-stream"            % akkaVersion,
-  "com.typesafe.akka"   %% "akka-persistence-tck"   % akkaVersion   % "test",
-  "com.typesafe.akka"   %% "akka-testkit"           % akkaVersion   % "test",
-  "org.scalatest"       %% "scalatest"              % "3.0.1"       % "test",
-  "commons-io"          % "commons-io"              % "2.4"         % "test",
-  "org.hdrhistogram"    % "HdrHistogram"            % "2.1.8"       % "test"
+  "com.lightbend.akka" %% "akka-stream-alpakka-dynamodb"  % "0.6",
+  "com.typesafe.akka"   %% "akka-persistence"             % akkaVersion,
+  "com.typesafe.akka"   %% "akka-stream"                  % akkaVersion,
+  "com.typesafe.akka"   %% "akka-persistence-tck"         % akkaVersion   % "test",
+  "com.typesafe.akka"   %% "akka-testkit"                 % akkaVersion   % "test",
+  "org.scalatest"       %% "scalatest"                    % "3.0.1"       % "test",
+  "commons-io"          % "commons-io"                    % "2.4"         % "test",
+  "org.hdrhistogram"    % "HdrHistogram"                  % "2.1.8"       % "test",
+  "org.mockito"         % "mockito-core"                  % "2.7.19"      % "test"
 )
 
 parallelExecution in Test := false

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd $(dirname $0)/..
 

--- a/scripts/get-dynamodb-local
+++ b/scripts/get-dynamodb-local
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ROOT=$(cd $(dirname $0)/..; pwd)
 

--- a/scripts/kill-dynamoDB.sh
+++ b/scripts/kill-dynamoDB.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd $(dirname $0)/..
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -58,7 +58,7 @@ dynamodb-journal {
   # empty in order to use the default credentials provider chain, see
   # http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/credentials.html#using-the-default-credential-provider-chain
   aws-secret-access-key = ""
-  
+
   # number of concurrently running replay prefetch operations for a
   # single PersistentActor; this prefetch means that during a replay
   # more events might be retrieved than specified with the `max`
@@ -77,6 +77,8 @@ dynamodb-journal {
     max-batch-get = 100
     max-batch-write = 25
     max-item-size = 400000
+    max-retries = 10
+    initial-backoff-ms = 100 // milliseconds
   }
   
   # AWS client configuration settings, see
@@ -90,7 +92,6 @@ dynamodb-journal {
     connection-timeout = default           # int
     connection-ttl = default               # long
     local-address = default                # InetAddress
-    max-connections = default              # int
     max-error-retry = default              # int
     preemptive-basic-proxy-auth = default  # boolean
     protocol = default                     # HTTP or HTTPS
@@ -120,4 +121,13 @@ dynamodb-journal {
       parallelism-max = 8
     }
   }
+
+  akka.stream.alpakka.dynamodb {
+    port = 8000
+    host = "localhost"
+    region = us-east-1
+    parallelism = 5
+  }
 }
+
+

--- a/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBHelper.scala
+++ b/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBHelper.scala
@@ -1,134 +1,108 @@
 /**
  * Copyright (C) 2016 Typesafe Inc. <http://www.typesafe.com>
  */
+
 package akka.persistence.dynamodb.journal
 
-import com.amazonaws.{ AmazonServiceException, AmazonWebServiceRequest }
-import com.amazonaws.handlers.AsyncHandler
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
-import com.amazonaws.services.dynamodbv2.model._
-import akka.actor.Scheduler
+import java.util.concurrent.atomic.AtomicInteger
+
+import akka.actor.{ ActorRef, Scheduler }
 import akka.event.LoggingAdapter
-import akka.pattern.after
-import java.util.{ concurrent => juc }
+import akka.stream.alpakka.dynamodb.AwsOp
+import akka.stream.alpakka.dynamodb.scaladsl.DynamoClient
+import akka.stream.alpakka.dynamodb.scaladsl.DynamoImplicits.{ BatchGetItem, BatchWriteItem, DescribeTable, PutItem, Query }
+import com.amazonaws.AmazonWebServiceRequest
+import com.amazonaws.services.dynamodbv2.model._
+
 import scala.collection.JavaConverters._
-import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.concurrent.duration._
-import scala.reflect.ClassTag
-import scala.util.control.NoStackTrace
-import akka.actor.ActorRef
+import scala.concurrent.{ ExecutionContext, Future }
 
 case class LatencyReport(nanos: Long, retries: Int)
-private class RetryStateHolder(var retries: Int = 10, var backoff: FiniteDuration = 1.millis)
 
 trait DynamoDBHelper {
-
   implicit val ec: ExecutionContext
-  val scheduler: Scheduler
-  val dynamoDB: AmazonDynamoDBAsyncClient
+
+  val client: DynamoClient
   val log: LoggingAdapter
   val settings: DynamoDBJournalConfig
-  import settings._
+  var reporter: Option[ActorRef] = None
 
-  def shutdown(): Unit = dynamoDB.shutdown()
+  def query(request: QueryRequest): Future[QueryResult] = sendSingleRequest(new Query(request))
 
-  private var reporter: ActorRef = _
-  def setReporter(ref: ActorRef): Unit = reporter = ref
+  def batchGetItem(request: BatchGetItemRequest): Future[BatchGetItemResult] =
+    sendSingleRequest(new BatchGetItem(request))
 
-  private def send[In <: AmazonWebServiceRequest, Out](aws: In, func: AsyncHandler[In, Out] => juc.Future[Out])(implicit d: Describe[_ >: In]): Future[Out] = {
+  def putItem(request: PutItemRequest): Future[PutItemResult] =
+    sendSingleRequest(new PutItem(request))
 
-    def name = d.desc(aws)
+  def batchWriteItem(request: BatchWriteItemRequest): Future[BatchWriteItemResult] =
+    sendSingleRequest(new BatchWriteItem(request))
 
-    def sendSingle(): Future[Out] = {
-      val p = Promise[Out]
+  def setReporter(ref: ActorRef): Unit = this.reporter = Some(ref)
 
-      val handler = new AsyncHandler[In, Out] {
-        override def onError(ex: Exception) = ex match {
-          case e: ProvisionedThroughputExceededException =>
-            p.tryFailure(ex)
-          case _ =>
-            val n = name
-            log.error(ex, "failure while executing {}", n)
-            p.tryFailure(new DynamoDBJournalFailure("failure while executing " + n, ex))
-        }
-        override def onSuccess(req: In, resp: Out) = p.trySuccess(resp)
+  def describeTable(request: DescribeTableRequest): Future[DescribeTableResult] =
+    sendSingleRequest(new DescribeTable(request))
+
+  private[journal] def sendSingleRequest(
+    awsOp: AwsOp
+  ): Future[awsOp.B] = {
+    val remainingRetries = new AtomicInteger(settings.ApiRequestMaxRetries)
+    val initialBackoff = settings.ApiRequestInitialBackoff.millis
+    val start = System.nanoTime()
+    val operationName = Describe.describe(awsOp.request)
+    val f = retry(initialBackoff, remainingRetries)(() => client.single(awsOp))
+
+    reporter.foreach(r => f.onComplete(_ => r ! LatencyReport(System.nanoTime - start, settings.ApiRequestMaxRetries - remainingRetries.get())))
+
+    // Wrapping the resulting future and log a message. The tests made me do it.
+    // Preserves the log ordering expected by the original tests
+
+    f.asInstanceOf[Future[awsOp.B]]
+      .transform(
+        identity, {
+        case pe: ProvisionedThroughputExceededException => pe
+        case e =>
+          log.error(
+            e,
+            "failure while executing {}",
+            operationName
+          )
+          new DynamoDBJournalFailure("failure while executing " + operationName, e)
       }
-
-      try {
-        func(handler)
-      } catch {
-        case ex: Throwable =>
-          log.error(ex, "failure while preparing {}", name)
-          p.tryFailure(ex)
-      }
-
-      p.future
-    }
-
-    val state = new RetryStateHolder
-
-    lazy val retry: PartialFunction[Throwable, Future[Out]] = {
-      case _: ProvisionedThroughputExceededException if state.retries > 0 =>
-        val backoff = state.backoff
-        state.retries -= 1
-        state.backoff *= 2
-        after(backoff, scheduler)(sendSingle().recoverWith(retry))
-      case other => Future.failed(other)
-    }
-
-    if (Tracing) log.debug("{}", name)
-    val start = if (reporter ne null) System.nanoTime else 0L
-
-    // backoff retries when sending too fast
-    val f = sendSingle().recoverWith(retry)
-
-    if (reporter ne null) f.onComplete(_ => reporter ! LatencyReport(System.nanoTime - start, 10 - state.retries))
-
-    f
+      )
   }
 
-  trait Describe[T] {
-    def desc(t: T): String
-    protected def formatKey(i: Item): String = {
-      val key = i.get(Key) match { case null => "<none>" case x => x.getS }
-      val sort = i.get(Sort) match { case null => "<none>" case x => x.getN }
-      s"[$Key=$key,$Sort=$sort]"
+  def retry[A](backoff: FiniteDuration, retries: AtomicInteger)(f: () => Future[A]): Future[A] = {
+    f().recoverWith {
+      case e: ProvisionedThroughputExceededException =>
+        if (retries.getAndDecrement() > 0) {
+          Future {
+            log.error(s"ProvisionedThroughputExceededException, backing of $backoff ms, retries left ${retries.get()}")
+            Thread.sleep(backoff.toMillis)
+          }.flatMap(_ => retry(backoff * 2, retries)(f))
+        } else Future.failed(e)
     }
   }
+}
 
-  object Describe {
-    implicit object GenericDescribe extends Describe[AmazonWebServiceRequest] {
-      def desc(aws: AmazonWebServiceRequest): String = aws.getClass.getSimpleName
+object Describe {
+
+  private def formatKey(i: Item): String = {
+    val key = i.get(Key) match {
+      case null => "<none>"
+      case x    => x.getS
     }
-  }
-
-  implicit object DescribeDescribe extends Describe[DescribeTableRequest] {
-    def desc(aws: DescribeTableRequest): String = s"DescribeTableRequest(${aws.getTableName})"
-  }
-
-  implicit object QueryDescribe extends Describe[QueryRequest] {
-    def desc(aws: QueryRequest): String = s"QueryRequest(${aws.getTableName},${aws.getExpressionAttributeValues})"
-  }
-
-  implicit object PutItemDescribe extends Describe[PutItemRequest] {
-    def desc(aws: PutItemRequest): String = s"PutItemRequest(${aws.getTableName},${formatKey(aws.getItem)})"
-  }
-
-  implicit object DeleteDescribe extends Describe[DeleteItemRequest] {
-    def desc(aws: DeleteItemRequest): String = s"DeleteItemRequest(${aws.getTableName},${formatKey(aws.getKey)})"
-  }
-
-  implicit object BatchGetItemDescribe extends Describe[BatchGetItemRequest] {
-    def desc(aws: BatchGetItemRequest): String = {
-      val entry = aws.getRequestItems.entrySet.iterator.next()
-      val table = entry.getKey
-      val keys = entry.getValue.getKeys.asScala.map(formatKey)
-      s"BatchGetItemRequest($table, ${keys.mkString("(", ",", ")")})"
+    val sort = i.get(Sort) match {
+      case null => "<none>"
+      case x    => x.getN
     }
+    s"[$Key=$key,$Sort=$sort]"
   }
 
-  implicit object BatchWriteItemDescribe extends Describe[BatchWriteItemRequest] {
-    def desc(aws: BatchWriteItemRequest): String = {
+  def describe(request: AmazonWebServiceRequest): String = request match {
+
+    case aws: BatchWriteItemRequest =>
       val entry = aws.getRequestItems.entrySet.iterator.next()
       val table = entry.getKey
       val keys = entry.getValue.asScala.map { write =>
@@ -138,46 +112,17 @@ trait DynamoDBHelper {
         }
       }
       s"BatchWriteItemRequest($table, ${keys.mkString("(", ",", ")")})"
-    }
+    case aws: BatchGetItemRequest =>
+      val entry = aws.getRequestItems.entrySet.iterator.next()
+      val table = entry.getKey
+      val keys = entry.getValue.getKeys.asScala.map(formatKey)
+      s"BatchGetItemRequest($table, ${keys.mkString("(", ",", ")")})"
+
+    case aws: DeleteItemRequest    => s"DeleteItemRequest(${aws.getTableName},${formatKey(aws.getKey)})"
+    case aws: PutItemRequest       => s"PutItemRequest(${aws.getTableName},${formatKey(aws.getItem)})"
+    case aws: QueryRequest         => s"QueryRequest(${aws.getTableName},${aws.getExpressionAttributeValues})"
+    case aws: DescribeTableRequest => s"DescribeTableRequest(${aws.getTableName})"
+    case aws                       => aws.getClass.getSimpleName
   }
-
-  def listTables(aws: ListTablesRequest): Future[ListTablesResult] =
-    send[ListTablesRequest, ListTablesResult](aws, dynamoDB.listTablesAsync(aws, _))
-
-  def describeTable(aws: DescribeTableRequest): Future[DescribeTableResult] =
-    send[DescribeTableRequest, DescribeTableResult](aws, dynamoDB.describeTableAsync(aws, _))
-
-  def createTable(aws: CreateTableRequest): Future[CreateTableResult] =
-    send[CreateTableRequest, CreateTableResult](aws, dynamoDB.createTableAsync(aws, _))
-
-  def updateTable(aws: UpdateTableRequest): Future[UpdateTableResult] =
-    send[UpdateTableRequest, UpdateTableResult](aws, dynamoDB.updateTableAsync(aws, _))
-
-  def deleteTable(aws: DeleteTableRequest): Future[DeleteTableResult] =
-    send[DeleteTableRequest, DeleteTableResult](aws, dynamoDB.deleteTableAsync(aws, _))
-
-  def query(aws: QueryRequest): Future[QueryResult] =
-    send[QueryRequest, QueryResult](aws, dynamoDB.queryAsync(aws, _))
-
-  def scan(aws: ScanRequest): Future[ScanResult] =
-    send[ScanRequest, ScanResult](aws, dynamoDB.scanAsync(aws, _))
-
-  def putItem(aws: PutItemRequest): Future[PutItemResult] =
-    send[PutItemRequest, PutItemResult](aws, dynamoDB.putItemAsync(aws, _))
-
-  def getItem(aws: GetItemRequest): Future[GetItemResult] =
-    send[GetItemRequest, GetItemResult](aws, dynamoDB.getItemAsync(aws, _))
-
-  def updateItem(aws: UpdateItemRequest): Future[UpdateItemResult] =
-    send[UpdateItemRequest, UpdateItemResult](aws, dynamoDB.updateItemAsync(aws, _))
-
-  def deleteItem(aws: DeleteItemRequest): Future[DeleteItemResult] =
-    send[DeleteItemRequest, DeleteItemResult](aws, dynamoDB.deleteItemAsync(aws, _))
-
-  def batchWriteItem(aws: BatchWriteItemRequest): Future[BatchWriteItemResult] =
-    send[BatchWriteItemRequest, BatchWriteItemResult](aws, dynamoDB.batchWriteItemAsync(aws, _))
-
-  def batchGetItem(aws: BatchGetItemRequest): Future[BatchGetItemResult] =
-    send[BatchGetItemRequest, BatchGetItemResult](aws, dynamoDB.batchGetItemAsync(aws, _))
 
 }

--- a/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBJournalConfig.scala
+++ b/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBJournalConfig.scala
@@ -4,17 +4,16 @@
 package akka.persistence.dynamodb.journal
 
 import com.typesafe.config.Config
-import akka.actor.ActorSystem
-import java.net.InetAddress
-import com.amazonaws.ClientConfiguration
-import com.amazonaws.Protocol
 
 class DynamoDBJournalConfig(c: Config) {
   val JournalTable = c getString "journal-table"
   val JournalName = c getString "journal-name"
-  val AwsKey = c getString "aws-access-key-id"
-  val AwsSecret = c getString "aws-secret-access-key"
-  val Endpoint = c getString "endpoint"
+
+  val AwsRegion = c getString "akka.stream.alpakka.dynamodb.region"
+  val DynamoPort = c getInt "akka.stream.alpakka.dynamodb.port"
+  val DynamoHost = c getString "akka.stream.alpakka.dynamodb.host"
+  val DynamoParallelism = c getInt "akka.stream.alpakka.dynamodb.parallelism"
+
   val ReplayDispatcher = c getString "replay-dispatcher"
   val ClientDispatcher = c getString "client-dispatcher"
   val SequenceShards = c getInt "sequence-shards"
@@ -26,56 +25,13 @@ class DynamoDBJournalConfig(c: Config) {
   val MaxBatchWrite = c getInt "aws-api-limits.max-batch-write"
   val MaxItemSize = c getInt "aws-api-limits.max-item-size"
 
-  object client {
-    private val cc = c getConfig "aws-client-config"
-    private def get[T](path: String, extract: (Config, String) => T, set: T => Unit): Unit =
-      if (cc.getString(path) == "default") ()
-      else {
-        val value = extract(cc, path)
-        set(value)
-        foundSettings ::= s"$path:$value"
-      }
-
-    private var foundSettings = List.empty[String]
-    override lazy val toString: String = foundSettings.reverse.mkString("{", ",", "}")
-    val config = new ClientConfiguration
-
-    get("client-execution-timeout", _.getInt(_), config.setClientExecutionTimeout)
-    get("connection-max-idle-millis", _.getLong(_), config.setConnectionMaxIdleMillis)
-    get("connection-timeout", _.getInt(_), config.setConnectionTimeout)
-    get("connection-ttl", _.getLong(_), config.setConnectionTTL)
-    get("local-address", (c, p) => InetAddress.getByName(c.getString(p)), config.setLocalAddress)
-    get("max-connections", _.getInt(_), config.setMaxConnections)
-    get("max-error-retry", _.getInt(_), config.setMaxErrorRetry)
-    get("preemptive-basic-proxy-auth", _.getBoolean(_), config.withPreemptiveBasicProxyAuth)
-    get("protocol", (c, p) => if (c.getString(p) == "HTTP") Protocol.HTTP else Protocol.HTTPS, config.setProtocol)
-    get("proxy-domain", _.getString(_), config.setProxyDomain)
-    get("proxy-host", _.getString(_), config.setProxyHost)
-    get("proxy-password", _.getString(_), config.setProxyPassword)
-    get("proxy-port", _.getInt(_), config.setProxyPort)
-    get("proxy-username", _.getString(_), config.setProxyUsername)
-    get("proxy-workstation", _.getString(_), config.setProxyWorkstation)
-    get("request-timeout", _.getInt(_), config.setRequestTimeout)
-    get("response-metadata-cache-size", _.getInt(_), config.setResponseMetadataCacheSize)
-    get("signer-override", _.getString(_), config.setSignerOverride)
-    get[(Int, Int)]("socket-buffer-size-hints", (c, p) => {
-      val tuple = c.getIntList(p)
-      require(tuple.size == 2, "socket-buffer-size-hints must be a list of two integers")
-      (tuple.get(0), tuple.get(1))
-    }, pair => config.setSocketBufferSizeHints(pair._1, pair._2))
-    get("socket-timeout", _.getInt(_), config.setSocketTimeout)
-    get("use-expect-continue", _.getBoolean(_), config.setUseExpectContinue)
-    get("use-gzip", _.getBoolean(_), config.setUseExpectContinue)
-    get("use-reaper", _.getBoolean(_), config.setUseReaper)
-    get("use-tcp-keepalive", _.getBoolean(_), config.setUseTcpKeepAlive)
-    get("user-agent", _.getString(_), config.setUserAgent)
-  }
+  val ApiRequestMaxRetries = c getInt "aws-api-limits.max-retries"
+  val ApiRequestInitialBackoff = c getInt "aws-api-limits.initial-backoff-ms"
 
   override def toString: String = "DynamoDBJournalConfig(" +
     "JournalTable:" + JournalTable +
     ",JournalName:" + JournalName +
-    ",AwsKey:" + AwsKey +
-    ",Endpoint:" + Endpoint +
+    ",AwsRegion:" + AwsRegion +
     ",ReplayDispatcher:" + ReplayDispatcher +
     ",ClientDispatcher:" + ClientDispatcher +
     ",SequenceShards:" + SequenceShards +
@@ -84,5 +40,7 @@ class DynamoDBJournalConfig(c: Config) {
     ",MaxBatchGet:" + MaxBatchGet +
     ",MaxBatchWrite:" + MaxBatchWrite +
     ",MaxItemSize:" + MaxItemSize +
-    ",client.config:" + client
+    ",ApiRequestMaxRetries:" + ApiRequestMaxRetries +
+    ",ApiRequestInitialBackoff:" + ApiRequestInitialBackoff +
+    ")"
 }

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -2,9 +2,6 @@ my-dynamodb-journal = ${dynamodb-journal}
 my-dynamodb-journal {
   journal-table =  "test-journal"
   journal-name =   "journal"
-  endpoint =  "http://localhost:8000"
-  aws-access-key-id = "set something in case no real creds are there"
-  aws-secret-access-key = "set something in case no real creds are there"
   tracing = off
 }
 

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBHelperRetrySpec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBHelperRetrySpec.scala
@@ -1,0 +1,47 @@
+package akka.persistence.dynamodb.journal
+
+import akka.event.LoggingAdapter
+import akka.stream.alpakka.dynamodb.AwsOp
+import akka.stream.alpakka.dynamodb.scaladsl.DynamoClient
+import akka.stream.alpakka.dynamodb.scaladsl.DynamoImplicits.ListTables
+import com.amazonaws.services.dynamodbv2.model.{ ListTablesRequest, ListTablesResult, ProvisionedThroughputExceededException }
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{ Matchers, WordSpec }
+import org.mockito.Mockito._
+import org.mockito.ArgumentMatchers._
+import scala.concurrent.duration._
+
+import scala.concurrent.{ Await, ExecutionContext, Future }
+
+class DynamoDBHelperRetrySpec extends WordSpec with Matchers with MockitoSugar {
+
+  "The DynamoDB Helper " should {
+
+    "perform a retry on a ThroughputException" in {
+
+      val testingEc = scala.concurrent.ExecutionContext.global
+      val dynamoClient = mock[DynamoClient]
+      val settingsMock = mock[DynamoDBJournalConfig]
+      val awsOp = new ListTables(mock[ListTablesRequest])
+
+      val helper = new DynamoDBHelper {
+        override val client: DynamoClient = dynamoClient
+        override val log: LoggingAdapter = mock[LoggingAdapter]
+        override implicit val ec: ExecutionContext = testingEc
+        override val settings: DynamoDBJournalConfig = settingsMock
+      }
+
+      when(dynamoClient.single(awsOp))
+        .thenReturn(Future.failed(new ProvisionedThroughputExceededException("bääää")))
+        .thenReturn(Future.successful(mock[ListTablesResult]))
+
+      when(settingsMock.ApiRequestMaxRetries).thenReturn(1)
+
+      val result = helper.sendSingleRequest(awsOp)
+
+      Await.result(result, 42.seconds)
+      verify(dynamoClient, times(2)).single(any[AwsOp])
+    }
+  }
+
+}

--- a/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBIntegrationLoadSpec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBIntegrationLoadSpec.scala
@@ -139,7 +139,6 @@ class DynamoDBIntegrationLoadSpec
   }
 
   override def afterAll(): Unit = {
-    client.shutdown()
     system.terminate()
   }
 

--- a/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBJournalSpec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBJournalSpec.scala
@@ -3,26 +3,26 @@
  */
 package akka.persistence.dynamodb.journal
 
+import akka.actor.ActorRef
+import akka.pattern.extended.ask
+import akka.persistence.CapabilityFlag
 import akka.persistence.journal.JournalSpec
-import com.amazonaws.services.dynamodbv2.model.{ CreateTableRequest, DeleteTableRequest, ListTablesRequest, ProvisionedThroughput }
 import com.typesafe.config.ConfigFactory
+
 import scala.concurrent.Await
 import scala.concurrent.duration._
-import akka.persistence.CapabilityFlag
-import scala.concurrent.Future
-import akka.pattern.extended.ask
-import akka.actor.ActorRef
 
 class DynamoDBJournalSpec extends JournalSpec(ConfigFactory.load()) with DynamoDBUtils {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
+    System.setProperty("aws.accessKeyId", "NotUsed")
+    System.setProperty("aws.secretKey", "NotUsed")
     ensureJournalTableExists()
   }
 
   override def afterAll(): Unit = {
     super.afterAll()
-    client.shutdown()
   }
 
   override def writeMessages(fromSnr: Int, toSnr: Int, pid: String, sender: ActorRef, writerUuid: String): Unit = {

--- a/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBTestingHelper.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBTestingHelper.scala
@@ -1,0 +1,20 @@
+package akka.persistence.dynamodb.journal
+
+import akka.stream.alpakka.dynamodb.scaladsl.DynamoImplicits.{ CreateTable, DeleteItem, ListTables }
+import com.amazonaws.services.dynamodbv2.model._
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+case class LatencyReport(nanos: Long, retries: Int)
+private class RetryStateHolder(var retries: Int = 10, var backoff: FiniteDuration = 1.millis)
+
+trait DynamoDBTestingHelper extends DynamoDBHelper {
+
+  def deleteItem(request: DeleteItemRequest): Future[DeleteItemResult] = sendSingleRequest(new DeleteItem(request))
+
+  def createTable(request: CreateTableRequest): Future[CreateTableResult] = sendSingleRequest(new CreateTable(request))
+
+  def listTables(request: ListTablesRequest): Future[ListTablesResult] = sendSingleRequest(new ListTables(request))
+
+}

--- a/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBUtils.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBUtils.scala
@@ -3,30 +3,35 @@
  */
 package akka.persistence.dynamodb.journal
 
-import com.amazonaws.services.dynamodbv2.model._
-import scala.concurrent.Await
-import akka.actor.ActorSystem
-import scala.concurrent.Future
-import scala.concurrent.duration._
-import akka.persistence.Persistence
-import akka.util.Timeout
 import java.util.UUID
+
+import akka.actor.ActorSystem
+import akka.event.Logging
 import akka.persistence.PersistentRepr
+import akka.stream.ActorMaterializer
+import akka.stream.alpakka.dynamodb.impl.DynamoSettings
+import akka.stream.alpakka.dynamodb.scaladsl.DynamoClient
+import akka.util.Timeout
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.services.dynamodbv2.model._
+
 import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+import scala.concurrent.{ Await, Future }
 
 trait DynamoDBUtils {
 
   val system: ActorSystem
   import system.dispatcher
 
-  lazy val settings = {
+  lazy val settings: DynamoDBJournalConfig = {
     val c = system.settings.config
     val config = c.getConfig(c.getString("akka.persistence.journal.plugin"))
     new DynamoDBJournalConfig(config)
   }
   import settings._
 
-  lazy val client = dynamoClient(system, settings)
+  lazy val client: DynamoDBTestingHelper = dynamoClient(system, settings)
 
   implicit val timeout = Timeout(5.seconds)
 
@@ -71,5 +76,22 @@ trait DynamoDBUtils {
     val ret = PersistentRepr(msg, sequenceNr = seqNr(), persistenceId = persistenceId, writerUuid = writerUuid)
     generatedMessages :+= ret
     ret
+  }
+
+  private def dynamoClient(system: ActorSystem, config: DynamoDBJournalConfig): DynamoDBTestingHelper = {
+    val dynamoSettings = new DynamoSettings(region = settings.AwsRegion, host = "localhost", port = 8000, parallelism = 5)
+    implicit val implicitSystem = system
+    implicit val mat = ActorMaterializer()
+
+    val alpakkaDynamoClient = new DynamoClient(dynamoSettings)
+
+    val dispatcher = system.dispatchers.lookup(settings.ClientDispatcher)
+
+    new DynamoDBTestingHelper {
+      override val ec = system.dispatcher
+      override val client = alpakkaDynamoClient
+      override val settings = config
+      override val log = Logging(system, "DynamoDBClient")
+    }
   }
 }

--- a/src/test/scala/akka/persistence/dynamodb/journal/FailureReportingSpec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/FailureReportingSpec.scala
@@ -3,19 +3,19 @@
  */
 package akka.persistence.dynamodb.journal
 
-import org.scalatest._
-import org.scalatest.concurrent.ScalaFutures
-import org.scalactic.ConversionCheckedTripleEquals
 import akka.actor._
-import akka.testkit._
-import scala.concurrent.duration._
-import com.typesafe.config.ConfigFactory
-import akka.persistence._
-import com.amazonaws.services.dynamodbv2.model._
 import akka.event.Logging
 import akka.persistence.JournalProtocol._
-import java.util.UUID
+import akka.persistence._
+import akka.testkit._
+import com.amazonaws.services.dynamodbv2.model._
+import com.typesafe.config.ConfigFactory
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest._
+import org.scalatest.concurrent.ScalaFutures
+
 import scala.collection.JavaConverters._
+import scala.concurrent.duration._
 
 class FailureReportingSpec extends TestKit(ActorSystem("FailureReportingSpec"))
     with ImplicitSender
@@ -23,7 +23,7 @@ class FailureReportingSpec extends TestKit(ActorSystem("FailureReportingSpec"))
     with BeforeAndAfterAll
     with Matchers
     with ScalaFutures
-    with ConversionCheckedTripleEquals
+    with TypeCheckedTripleEquals
     with DynamoDBUtils {
 
   implicit val patience = PatienceConfig(5.seconds)
@@ -46,9 +46,13 @@ class FailureReportingSpec extends TestKit(ActorSystem("FailureReportingSpec"))
     rej.cause.getMessage should include regex msg
   }
 
-  override def beforeAll(): Unit = ensureJournalTableExists()
+  override def beforeAll(): Unit = {
+    System.setProperty("aws.accessKeyId", "NotUsed")
+    System.setProperty("aws.secretKey", "NotUsed")
+    ensureJournalTableExists()
+  }
+
   override def afterAll(): Unit = {
-    client.shutdown()
     system.terminate().futureValue
   }
 
@@ -85,18 +89,6 @@ class FailureReportingSpec extends TestKit(ActorSystem("FailureReportingSpec"))
           }
         }
       } finally system.terminate()
-    }
-
-    "notify user about used config" in {
-      val config = ConfigFactory
-        .parseString("my-dynamodb-journal{log-config=on\naws-client-config.protocol=HTTPS}")
-        .withFallback(ConfigFactory.load())
-      implicit val system = ActorSystem("FailureReportingSpec-test3", config)
-      try
-        EventFilter.info(pattern = ".*protocol:https.*", occurrences = 1).intercept {
-          Persistence(system).journalFor("")
-        }
-      finally system.terminate()
     }
 
     "not notify user about config errors when starting the default journal" in {
@@ -183,59 +175,59 @@ akka.loggers = ["akka.testkit.TestEventListener"]
     }
 
     "have sensible error messages" when {
-      import client._
-      def desc[T](aws: T)(implicit d: Describe[_ >: T]): String = d.desc(aws)
+      import Describe._
+
       val keyItem = Map(Key -> S("TheKey"), Sort -> N("42")).asJava
       val key2Item = Map(Key -> S("The2Key"), Sort -> N("43")).asJava
 
       "reporting table problems" in {
         val aws = new DescribeTableRequest().withTableName("TheTable")
-        desc(aws) should include("DescribeTable")
-        desc(aws) should include("TheTable")
+        describe(aws) should include("DescribeTable")
+        describe(aws) should include("TheTable")
       }
 
       "reporting putItem problems" in {
         val aws = new PutItemRequest().withTableName("TheTable").withItem(keyItem)
-        desc(aws) should include("PutItem")
-        desc(aws) should include("TheTable")
-        desc(aws) should include("TheKey")
-        desc(aws) should include("42")
+        describe(aws) should include("PutItem")
+        describe(aws) should include("TheTable")
+        describe(aws) should include("TheKey")
+        describe(aws) should include("42")
       }
 
       "reporting deleteItem problems" in {
         val aws = new DeleteItemRequest().withTableName("TheTable").withKey(keyItem)
-        desc(aws) should include("DeleteItem")
-        desc(aws) should include("TheTable")
-        desc(aws) should include("TheKey")
-        desc(aws) should include("42")
+        describe(aws) should include("DeleteItem")
+        describe(aws) should include("TheTable")
+        describe(aws) should include("TheKey")
+        describe(aws) should include("42")
       }
 
       "reporting query problems" in {
         val aws = new QueryRequest().withTableName("TheTable").withExpressionAttributeValues(Map(":kkey" -> S("TheKey")).asJava)
-        desc(aws) should include("Query")
-        desc(aws) should include("TheTable")
-        desc(aws) should include("TheKey")
+        describe(aws) should include("Query")
+        describe(aws) should include("TheTable")
+        describe(aws) should include("TheKey")
       }
 
       "reporting batch write problems" in {
         val write = new WriteRequest().withPutRequest(new PutRequest().withItem(keyItem))
         val remove = new WriteRequest().withDeleteRequest(new DeleteRequest().withKey(key2Item))
         val aws = new BatchWriteItemRequest().withRequestItems(Map("TheTable" -> Seq(write, remove).asJava).asJava)
-        desc(aws) should include("BatchWriteItem")
-        desc(aws) should include("TheTable")
-        desc(aws) should include("put[par=TheKey,num=42]")
-        desc(aws) should include("del[par=The2Key,num=43]")
+        describe(aws) should include("BatchWriteItem")
+        describe(aws) should include("TheTable")
+        describe(aws) should include("put[par=TheKey,num=42]")
+        describe(aws) should include("del[par=The2Key,num=43]")
       }
 
       "reporting batch read problems" in {
         val ka = new KeysAndAttributes().withKeys(keyItem, key2Item)
         val aws = new BatchGetItemRequest().withRequestItems(Map("TheTable" -> ka).asJava)
-        desc(aws) should include("BatchGetItem")
-        desc(aws) should include("TheTable")
-        desc(aws) should include("TheKey")
-        desc(aws) should include("42")
-        desc(aws) should include("The2Key")
-        desc(aws) should include("43")
+        describe(aws) should include("BatchGetItem")
+        describe(aws) should include("TheTable")
+        describe(aws) should include("TheKey")
+        describe(aws) should include("42")
+        describe(aws) should include("The2Key")
+        describe(aws) should include("43")
       }
     }
 

--- a/src/test/scala/akka/persistence/dynamodb/journal/WriteThroughputBench.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/WriteThroughputBench.scala
@@ -159,7 +159,6 @@ writer-dispatcher {
   scala.io.StdIn.readLine()
 
   system.terminate()
-  client.shutdown()
 
   def printStats(r: Report): Unit = {
     def p(h: Histogram, pc: Double) = h.getValueAtPercentile(pc) / 1000000d

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.1"
+version in ThisBuild := "1.1.0"


### PR DESCRIPTION
- Removes AWS SDK
- Adds Alpakka as new Client
- To perform a clean change we refactored the DynamoDBJournal so that the Helper can be replaced in isolation.
- Introduces settings for Backoff and Retries instead of magic numbers.
- Refactored Describe from Type Class to pattern matching for better testablility and simpler code
- Removed no longer used AWS Client Settings
- Removed Documentation of Threading Issue from Readme
- Bump Version to 1.1.0
- Use default AWS credential provider chain instead of config values

This fixes issue #3