### PR TITLE
Stop the DynamoDB client that is used by the snapshot store actor

### DIFF
--- a/src/main/scala/akka/persistence/dynamodb/snapshot/DynamoDBSnapshotStore.scala
+++ b/src/main/scala/akka/persistence/dynamodb/snapshot/DynamoDBSnapshotStore.scala
@@ -23,6 +23,9 @@ class DynamoDBSnapshotStore(config: Config) extends SnapshotStore with DynamoDBS
     self ! DynamoDBSnapshotStore.Init
   }
 
+  override def postStop(): Unit =
+    dynamo.shutdown()
+
   override def loadAsync(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Option[SelectedSnapshot]] =
     load(persistenceId, criteria)
 


### PR DESCRIPTION
This is already being done in the [journal actor](https://github.com/akka/akka-persistence-dynamodb/blob/master/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBJournal.scala#L91)