### PR TITLE
Format correctly DynamoDBJournalConfig toString

### DIFF
--- a/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBJournalConfig.scala
+++ b/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBJournalConfig.scala
@@ -39,5 +39,6 @@ class DynamoDBJournalConfig(c: Config) extends DynamoDBConfig {
     ",MaxBatchGet:" + MaxBatchGet +
     ",MaxBatchWrite:" + MaxBatchWrite +
     ",MaxItemSize:" + MaxItemSize +
-    ",client.config:" + client
+    ",client.config:" + client +
+    ")"
 }


### PR DESCRIPTION
A parenthesis is missing. Big contribution, you are welcome :trollface: 