### PR TITLE
Reduce duplicate error reporting

### DIFF
--- a/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBHelper.scala
+++ b/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBHelper.scala
@@ -50,7 +50,6 @@ trait DynamoDBHelper {
             p.tryFailure(ex)
           case _ =>
             val n = name
-            log.error(ex, "failure while executing {}", n)
             p.tryFailure(new DynamoDBJournalFailure("failure while executing " + n, ex))
         }
         override def onSuccess(req: In, resp: Out) = p.trySuccess(resp)
@@ -60,7 +59,6 @@ trait DynamoDBHelper {
         func(handler)
       } catch {
         case ex: Throwable =>
-          log.error(ex, "failure while preparing {}", name)
           p.tryFailure(ex)
       }
 


### PR DESCRIPTION
## Purpose

Right now I get error logging twice. Once via the `SaveSnapshotFailure` mechanism  and also directly from this `DynamoDBHelper`. Would be better if it was only once and I guess the `SaveSnapshotFailure` makes more sense.

## Issue
https://github.com/akka/akka-persistence-dynamodb/issues/81

