### PR TITLE
Up sbt dependency to 1.2.8. aws to 1.11.602

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ crossScalaVersions := Seq("2.11.12", "2.12.8")
 crossVersion       := CrossVersion.binary
 
 val akkaVersion = "2.5.23"
-val amzVersion = "1.11.119"
+val amzVersion = "1.11.602"
 
 libraryDependencies ++= Seq(
   "com.amazonaws"       % "aws-java-sdk-core"       % amzVersion,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=1.2.8


### PR DESCRIPTION
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Purpose

Corrects build: The updated sbt plugins in #85 are not available for sbt 0.13.

## References

References #85 

## Changes

* any particular reason to still use 0.13?
* does not include the scalafmt changes that `test` induces
