### PR TITLE
Updates for release 1.2.0-RC2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ services:
 
 scala:
   - "2.11.12"
-  - "2.12.9"
-  - "2.13.1"
+  - "2.12.11"
+  - "2.13.3"
 
 before-install:
   - curl -sL https://raw.githubusercontent.com/shyiko/jabba/0.11.2/install.sh | bash && . ~/.jabba/jabba.sh

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@ DynamoDBJournal for Akka Persistence
 ====================================
 
 A replicated [Akka Persistence](http://doc.akka.io/docs/akka/2.4.0/scala/persistence.html) journal backed by
-[Amazon DynamoDB](http://aws.amazon.com/dynamodb/). 
+[Amazon DynamoDB](http://aws.amazon.com/dynamodb/).
 
 - This plugin implements both a journal as well as a snapshot store,
 - Please note, however, that it does not include an Akka Persistence Query plugin.
 
-Supported versions: 
-- Scala: `2.11.x` or `2.12.x`  
-- Akka: `2.4.14+` and `2.5.x+` and `2.6.x+` (see notes below how to use with 2.5)  
+Supported versions:
+- Scala: `2.11.x`, `2.12.x`, `2.13.x`
+- Akka: `2.4.14+` and `2.5.x+` and `2.6.x+` (see notes below how to use with 2.5)
 - Java: `1.8+`
 
 [![Join the chat at https://gitter.im/akka/akka-persistence-dynamodb](https://badges.gitter.im/akka/akka-persistence-dynamodb.svg)](https://gitter.im/akka/akka-persistence-dynamodb?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
@@ -24,14 +24,14 @@ This plugin is published to the Maven Central repository with the following name
 <dependency>
     <groupId>com.typesafe.akka</groupId>
     <artifactId>akka-persistence-dynamodb_2.11</artifactId>
-    <version>1.1.1</version>
+    <version>1.2.0</version>
 </dependency>
 ~~~
 
 or for sbt users:
 
 ```sbt
-libraryDependencies += "com.typesafe.akka" %% "akka-persistence-dynamodb" % "1.1.1"
+libraryDependencies += "com.typesafe.akka" %% "akka-persistence-dynamodb" % "1.2.0"
 ```
 
 Configuration
@@ -57,7 +57,7 @@ Before you can use these settings you will have to create a table, e.g. using th
 
   * a hash key of type String with name `par`
   * a sort key of type Number with name `num`
-  
+
 ### Snapshot store
 (**Since:** `1.1.0`; contributed by [@joost-de-vries](https://github.com/joost-de-vries))
 
@@ -75,13 +75,13 @@ my-dynamodb-snapshot-store {                     # and add some overrides
 ~~~
 
 The table to create for snapshot storage has the schema:
- 
+
 * a hash key of type String with name `par`
 * a sort key of type Number with name `seq`
 * a sort key of type Number with name `ts`
 * a local secondary index with name `ts-idx` that is an index on the combination of `par` and `ts`
 
-The Dynamodb item of a snapshot [can be 400 kB](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html#limits-items). Using a binary serialisation format like ProtoBuf or Kryo will use that space most effectively.  
+The Dynamodb item of a snapshot [can be 400 kB](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html#limits-items). Using a binary serialisation format like ProtoBuf or Kryo will use that space most effectively.
 
 Storage Semantics
 -----------------
@@ -197,7 +197,7 @@ When writing an item we typically do not touch the high sequence number storage,
 Using with Akka 2.5.x
 ---------------------
 
-This plugin depends on Akka 2.4, however since [Akka maintains strict backwards compatibility guarantees](http://doc.akka.io/docs/akka/current/scala/common/binary-compatibility-rules.html) across minor versions, 
+This plugin depends on Akka 2.4, however since [Akka maintains strict backwards compatibility guarantees](http://doc.akka.io/docs/akka/current/scala/common/binary-compatibility-rules.html) across minor versions,
 it is completely compatible to use this plugin with Akka 2.5.x.
 
 Please make sure to depend on all Akka artifacts (those with the artifact name begining with `akka-*`) are depended on in the same version - as mixing versions is *not* legal. For example, if you depend on Akka Persistence in `2.5.3`, make sure that Akka Streams and Actors are also depended on in the same version. Please always use the latest patch version available (!).
@@ -239,7 +239,7 @@ to make the change backwards compatible.
 Credits
 -------
 
-- Initial development was done by [Scott Clasen](https://github.com/sclasen/akka-persistence-dynamodb). 
+- Initial development was done by [Scott Clasen](https://github.com/sclasen/akka-persistence-dynamodb).
 - Update to Akka 2.4 and further development up to version 1.0 was kindly sponsored by [Zynga Inc.](https://www.zynga.com/).
 - The snapshot store was contributed by [Joost de Vries](https://github.com/joost-de-vries)
 

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ This plugin is published to the Maven Central repository with the following name
 <dependency>
     <groupId>com.typesafe.akka</groupId>
     <artifactId>akka-persistence-dynamodb_2.11</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.0-RC2</version>
 </dependency>
 ~~~
 
 or for sbt users:
 
 ```sbt
-libraryDependencies += "com.typesafe.akka" %% "akka-persistence-dynamodb" % "1.2.0"
+libraryDependencies += "com.typesafe.akka" %% "akka-persistence-dynamodb" % "1.2.0-RC2"
 ```
 
 Configuration

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,7 +5,6 @@ How to release
 - commit
 - tag it as `vX.Y.Z`
 - push things
-- `sbt -Dpublish.maven.central=true publishSigned` and remember to publish for 2.12 as well
-  - `++2.12.X` && `publishSigned`
-- update the `akka-persistence-dynamodb-xx-stable` reporting project in [WhiteSource](http://saas.whitesourcesoftware.com/)
-- `sbt whitesourceUpdate`
+- `sbt -Dpublish.maven.central=true ++publishSigned`
+- Travis CI will update the `akka-persistence-dynamodb-xx-stable` reporting project in
+  [WhiteSource](http://saas.whitesourcesoftware.com/) on push to master.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,10 +1,13 @@
 How to release
 --------------
 
-- edit the `version.sbt` file
-- commit
-- tag it as `vX.Y.Z`
-- push things
+- create an annotated tag for the next version. EG: `git tag -a -m 'release v1.2.0-RC2' v1.2.0-RC2`
+- push tags and commits to akka remote master
+- If the workspace is not clean or HEAD != the tag then published version will be a snapshot. To use
+  exactly the tagged version the workspace must be clean and there are no additional commits beyond
+  the tag.
 - `sbt -Dpublish.maven.central=true ++publishSigned`
 - Travis CI will update the `akka-persistence-dynamodb-xx-stable` reporting project in
   [WhiteSource](http://saas.whitesourcesoftware.com/) on push to master.
+  The `xx` is the `major.minor` of the current version. This needs a manual update when
+  the minor version is incremented.

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "akka-persistence-dynamodb"
 
-scalaVersion       := "2.11.12"
-crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0")
+scalaVersion       := "2.12.11"
+crossScalaVersions := Seq("2.11.12", "2.12.11", "2.13.3")
 crossVersion       := CrossVersion.binary
 
 val akkaVersion = "2.5.29"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,6 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 addSbtPlugin("com.lightbend" % "sbt-whitesource"  % "0.1.7")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
+
+// https://github.com/dwijnand/sbt-dynver
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "1.1.2-SNAPSHOT"


### PR DESCRIPTION
There are currently no scala 2.13 artifacts published. See #94

This pull request includes updates for a 1.2.0-RC2 release. Which includes the changes for scala 2.13.