### PR TITLE
WIP: improve testing - github actions and dynamodb test container

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -1,0 +1,80 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - release-*
+      - 1.1.x
+    tags-ignore: [ v.* ]
+
+env:
+  AKKA_TEST_TIMEFACTOR: 10.0
+  EVENT_NAME: ${{ github.event_name }}
+
+jobs:
+  check-code-compilation:
+    name: Check Code Compilation
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Checkout GitHub merge
+        if: github.event.pull_request
+        run: |-
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
+          git checkout scratch
+
+      - name: Set up JDK 11
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11.0-9
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v5
+
+      - name: Compile all code with default compiler
+        run: sbt "; Test/compile"
+
+  test:
+    name: Build and Test
+    runs-on: ubuntu-18.04
+    needs: [check-code-compilation]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { java-version: adopt@1.8,      scala-version: 2.11.12, sbt-opts: '' }
+          - { java-version: adopt@1.8,      scala-version: 2.12.13, sbt-opts: '' }
+          - { java-version: adopt@1.11.0-9, scala-version: 2.11.12,  sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { java-version: adopt@1.11.0-9, scala-version: 2.12.13, sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Checkout GitHub merge
+        if: github.event.pull_request
+        run: |-
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
+          git checkout scratch
+
+      - name: Setup Scala with Java ${{ matrix.java-version }}
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: ${{ matrix.java-version }}
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v5
+
+      - name: Run tests with Scala ${{ matrix.scala-version }} and Java ${{ matrix.java-version }}
+        run: sbt "++${{ matrix.scala-version }} test" ${{ matrix.sbt-opts }}
+
+      - name: Print logs on failure
+        if: ${{ failure() }}
+        run: find . -name "*.log" -exec ./scripts/cat-log.sh {} \;

--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - main
       - release-*
       - 1.1.x
     tags-ignore: [ v.* ]
@@ -16,7 +17,7 @@ env:
 jobs:
   check-code-compilation:
     name: Check Code Compilation
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -38,11 +39,11 @@ jobs:
         uses: coursier/cache-action@v5
 
       - name: Compile all code with default compiler
-        run: sbt "; Test/compile"
+        run: sbt Test/compile
 
   test:
     name: Build and Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: [check-code-compilation]
     strategy:
       fail-fast: false

--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -48,10 +48,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { java-version: adopt@1.8,      scala-version: 2.11.12, sbt-opts: '' }
           - { java-version: adopt@1.8,      scala-version: 2.12.13, sbt-opts: '' }
-          - { java-version: adopt@1.11.0-9, scala-version: 2.11.12,  sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
-          - { java-version: adopt@1.11.0-9, scala-version: 2.12.13, sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { java-version: adopt@1.8,      scala-version: 2.13.5, sbt-opts: '' }
+          - { java-version: adopt@1.11.0-9, scala-version: 2.12.13,  sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { java-version: adopt@1.11.0-9, scala-version: 2.13.5, sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,6 +1,5 @@
 -Dfile.encoding=UTF8
 -Xms1g
--Xmx1g
+-Xmx4g
 -Xss6M
 -XX:+CMSClassUnloadingEnabled
--XX:+UseConcMarkSweepGC

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ crossVersion       := CrossVersion.binary
 
 val akkaVersion = "2.5.29"
 val amzVersion = "1.11.602"
+val testcontainersScalaVersion = "0.39.8"
 
 libraryDependencies ++= Seq(
   "com.amazonaws"       % "aws-java-sdk-core"       % amzVersion,
@@ -16,18 +17,19 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka"   %% "akka-testkit"           % akkaVersion   % "test",
   "org.scalatest"       %% "scalatest"              % "3.0.8"       % "test",
   "commons-io"          % "commons-io"              % "2.4"         % "test",
-  "org.hdrhistogram"    % "HdrHistogram"            % "2.1.8"       % "test"
+  "org.hdrhistogram"    % "HdrHistogram"            % "2.1.8"       % "test",
+  "com.dimafeng"        %% "testcontainers-scala-scalatest" % testcontainersScalaVersion % "test"
 )
 
-parallelExecution in Test := false
+Test / parallelExecution := false
 logBuffered := false
-testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF")
+Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oDF")
 
 import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 
 ScalariformKeys.autoformat := true
-ScalariformKeys.preferences in Compile  := formattingPreferences
-ScalariformKeys.preferences in Test     := formattingPreferences
+Compile / ScalariformKeys.preferences := formattingPreferences
+Test / ScalariformKeys.preferences := formattingPreferences
 
 def formattingPreferences = {
   import scalariform.formatter.preferences._
@@ -36,6 +38,6 @@ def formattingPreferences = {
     .setPreference(AlignParameters, true)
     .setPreference(AlignSingleLineCaseStatements, true)
     .setPreference(SpacesAroundMultiImports, true)
-    .setPreference(DoubleIndentClassDeclaration, true)
+    .setPreference(DoubleIndentConstructorArguments, true)
     .setPreference(AlignArguments, true)
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "akka-persistence-dynamodb"
 
-scalaVersion       := "2.12.11"
-crossScalaVersions := Seq("2.11.12", "2.12.11", "2.13.3")
+scalaVersion       := "2.13.5"
+crossScalaVersions := Seq("2.12.13", "2.13.5")
 crossVersion       := CrossVersion.binary
 
 val akkaVersion = "2.5.29"

--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,8 @@ libraryDependencies ++= Seq(
 )
 
 Test / parallelExecution := false
+// required by test-containers-scala
+Test / fork := true
 logBuffered := false
 Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oDF")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.8
+sbt.version=1.5.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 

--- a/src/main/scala/akka/persistence/dynamodb/package.scala
+++ b/src/main/scala/akka/persistence/dynamodb/package.scala
@@ -66,11 +66,11 @@ package object dynamodb {
     val dispatcher = system.dispatchers.lookup(settings.ClientDispatcher)
 
     class DynamoDBClient(
-      override val ec:        ExecutionContext,
-      override val dynamoDB:  AmazonDynamoDBAsyncClient,
-      override val settings:  DynamoDBConfig,
-      override val scheduler: Scheduler,
-      override val log:       LoggingAdapter) extends DynamoDBHelper
+        override val ec:        ExecutionContext,
+        override val dynamoDB:  AmazonDynamoDBAsyncClient,
+        override val settings:  DynamoDBConfig,
+        override val scheduler: Scheduler,
+        override val log:       LoggingAdapter) extends DynamoDBHelper
 
     new DynamoDBClient(dispatcher, client, settings, system.scheduler, Logging(system, "DynamoDBClient"))
   }

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -2,7 +2,7 @@ my-dynamodb-journal = ${dynamodb-journal}
 my-dynamodb-journal {
   journal-table =  "test-journal"
   journal-name =   "journal"
-  endpoint =  "http://localhost:8000"
+  endpoint =  "http://localhost:8888"
   aws-access-key-id = "AWS_ACCESS_KEY_ID"
   aws-secret-access-key = "AWS_SECRET_ACCESS_KEY"
   tracing = off
@@ -11,7 +11,7 @@ my-dynamodb-journal {
 my-dynamodb-snapshot-store = ${dynamodb-snapshot-store}
 my-dynamodb-snapshot-store {
   snapshot-table =  "test-snapshot"
-  endpoint =  "http://localhost:8000"
+  endpoint =  "http://localhost:8888"
   aws-access-key-id = "AWS_ACCESS_KEY_ID"
   aws-secret-access-key = "AWS_SECRET_ACCESS_KEY"
   tracing = off

--- a/src/test/scala/akka/persistence/dynamodb/IntegSpec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/IntegSpec.scala
@@ -1,0 +1,20 @@
+package akka.persistence.dynamodb
+
+import com.dimafeng.testcontainers.ForAllTestContainer
+import com.dimafeng.testcontainers.Container
+import org.scalatest.Suite
+import com.dimafeng.testcontainers.GenericContainer
+import com.dimafeng.testcontainers.FixedHostPortGenericContainer
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy
+
+/**
+ * Base spec for tests that verify integration with DynamoDB.
+ */
+trait IntegSpec extends ForAllTestContainer { self: Suite =>
+  // TODO: Use dynamic ports. This is a annoying to do as the actor system is init prior to beforeAll.
+  override val container: Container = FixedHostPortGenericContainer(
+    "amazon/dynamodb-local:latest",
+    exposedContainerPort = 8000,
+    exposedHostPort      = 8888,
+    waitStrategy         = new HttpWaitStrategy().forPath("/").forStatusCode(400))
+}

--- a/src/test/scala/akka/persistence/dynamodb/journal/AsyncDynamoDBJournalSpec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/AsyncDynamoDBJournalSpec.scala
@@ -11,6 +11,7 @@ import akka.persistence.CapabilityFlag
 import com.typesafe.config.ConfigFactory
 import scala.concurrent.duration._
 import scala.concurrent.Await
+import akka.persistence.dynamodb.IntegSpec
 
 object AsyncDynamoDBJournalSpec {
 
@@ -28,7 +29,7 @@ object AsyncDynamoDBJournalSpec {
 
 }
 
-class AsyncDynamoDBJournalSpec extends JournalSpec(AsyncDynamoDBJournalSpec.config) with DynamoDBUtils {
+class AsyncDynamoDBJournalSpec extends JournalSpec(AsyncDynamoDBJournalSpec.config) with DynamoDBUtils with IntegSpec {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -36,8 +37,8 @@ class AsyncDynamoDBJournalSpec extends JournalSpec(AsyncDynamoDBJournalSpec.conf
   }
 
   override def afterAll(): Unit = {
-    super.afterAll()
     client.shutdown()
+    super.afterAll()
   }
 
   override def writeMessages(fromSnr: Int, toSnr: Int, pid: String, sender: ActorRef, writerUuid: String): Unit = {

--- a/src/test/scala/akka/persistence/dynamodb/journal/BackwardsCompatibilityV1Spec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/BackwardsCompatibilityV1Spec.scala
@@ -17,6 +17,7 @@ import com.amazonaws.regions.Regions
 import com.amazonaws.services.dynamodbv2.{ AmazonDynamoDB, AmazonDynamoDBClient }
 import com.amazonaws.services.dynamodbv2.document.{ DynamoDB, Item }
 import com.typesafe.config.ConfigFactory
+import akka.persistence.dynamodb.IntegSpec
 
 class BackwardsCompatibilityV1Spec extends TestKit(ActorSystem("PartialAsyncSerializationSpec"))
   with ImplicitSender
@@ -25,7 +26,8 @@ class BackwardsCompatibilityV1Spec extends TestKit(ActorSystem("PartialAsyncSeri
   with Matchers
   with ScalaFutures
   with TypeCheckedTripleEquals
-  with DynamoDBUtils {
+  with DynamoDBUtils
+  with IntegSpec {
 
   def loadV1VersionData(): Unit = {
     val config = ConfigFactory.load()
@@ -82,11 +84,13 @@ class BackwardsCompatibilityV1Spec extends TestKit(ActorSystem("PartialAsyncSeri
   }
 
   override def beforeAll(): Unit = {
+    super.beforeAll()
     ensureJournalTableExists()
     loadV1VersionData()
   }
 
   override def afterAll(): Unit = {
+    super.afterAll()
     client.shutdown()
     system.terminate().futureValue
   }

--- a/src/test/scala/akka/persistence/dynamodb/journal/BackwardsCompatibilityV1Spec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/BackwardsCompatibilityV1Spec.scala
@@ -19,13 +19,13 @@ import com.amazonaws.services.dynamodbv2.document.{ DynamoDB, Item }
 import com.typesafe.config.ConfigFactory
 
 class BackwardsCompatibilityV1Spec extends TestKit(ActorSystem("PartialAsyncSerializationSpec"))
-    with ImplicitSender
-    with WordSpecLike
-    with BeforeAndAfterAll
-    with Matchers
-    with ScalaFutures
-    with TypeCheckedTripleEquals
-    with DynamoDBUtils {
+  with ImplicitSender
+  with WordSpecLike
+  with BeforeAndAfterAll
+  with Matchers
+  with ScalaFutures
+  with TypeCheckedTripleEquals
+  with DynamoDBUtils {
 
   def loadV1VersionData(): Unit = {
     val config = ConfigFactory.load()

--- a/src/test/scala/akka/persistence/dynamodb/journal/DeletionSpec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/DeletionSpec.scala
@@ -12,13 +12,13 @@ import akka.persistence._
 import akka.persistence.JournalProtocol._
 
 class DeletionSpec extends TestKit(ActorSystem("FailureReportingSpec"))
-    with ImplicitSender
-    with WordSpecLike
-    with BeforeAndAfterAll
-    with Matchers
-    with ScalaFutures
-    with TypeCheckedTripleEquals
-    with DynamoDBUtils {
+  with ImplicitSender
+  with WordSpecLike
+  with BeforeAndAfterAll
+  with Matchers
+  with ScalaFutures
+  with TypeCheckedTripleEquals
+  with DynamoDBUtils {
 
   override def beforeAll(): Unit = ensureJournalTableExists()
   override def afterAll(): Unit = {

--- a/src/test/scala/akka/persistence/dynamodb/journal/DeletionSpec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/DeletionSpec.scala
@@ -3,13 +3,15 @@
  */
 package akka.persistence.dynamodb.journal
 
+import akka.persistence.dynamodb.IntegSpec
+
+import akka.actor.ActorSystem
+import akka.persistence.JournalProtocol._
+import akka.persistence._
 import akka.testkit._
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
-import akka.actor.ActorSystem
-import akka.persistence._
-import akka.persistence.JournalProtocol._
 
 class DeletionSpec extends TestKit(ActorSystem("FailureReportingSpec"))
   with ImplicitSender
@@ -18,9 +20,14 @@ class DeletionSpec extends TestKit(ActorSystem("FailureReportingSpec"))
   with Matchers
   with ScalaFutures
   with TypeCheckedTripleEquals
-  with DynamoDBUtils {
+  with DynamoDBUtils
+  with IntegSpec {
 
-  override def beforeAll(): Unit = ensureJournalTableExists()
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    ensureJournalTableExists()
+  }
+
   override def afterAll(): Unit = {
     /*
      * The last operation is a ListAll which may spawn requests that linger
@@ -30,10 +37,11 @@ class DeletionSpec extends TestKit(ActorSystem("FailureReportingSpec"))
     Thread.sleep(500)
     system.terminate().futureValue
     client.shutdown()
+    super.afterAll()
   }
 
   override val persistenceId = "DeletionSpec"
-  val journal = Persistence(system).journalFor("")
+  lazy val journal = Persistence(system).journalFor("")
 
   "DynamoDB Journal (Deletion)" must {
 

--- a/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBIntegrationLoadSpec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBIntegrationLoadSpec.scala
@@ -9,6 +9,7 @@ import akka.persistence._
 import akka.testkit._
 import com.typesafe.config.ConfigFactory
 import org.scalatest._
+import akka.persistence.dynamodb.IntegSpec
 
 /**
  * This class is pulled from https://github.com/krasserm/akka-persistence-cassandra/
@@ -19,13 +20,15 @@ object DynamoDBIntegrationLoadSpec {
   val config = ConfigFactory.parseString("""
 my-dynamodb-journal {
   journal-table = "integrationLoadSpec"
+  endpoint =  "http://localhost:8888"
   endpoint = ${?AWS_DYNAMODB_ENDPOINT}
   aws-access-key-id = "set something in case no real creds are there"
   aws-access-key-id = ${?AWS_ACCESS_KEY_ID}
   aws-secret-access-key = "set something in case no real creds are there"
   aws-secret-access-key = ${?AWS_SECRET_ACCESS_KEY}
 }
-""").resolve.withFallback(ConfigFactory.load())
+akka.persistence.snapshot-store.plugin = ""
+""").withFallback(ConfigFactory.load()).resolve()
 
   case class DeleteTo(snr: Long)
 
@@ -116,7 +119,8 @@ class DynamoDBIntegrationLoadSpec
   with WordSpecLike
   with Matchers
   with BeforeAndAfterAll
-  with DynamoDBUtils {
+  with DynamoDBUtils
+  with IntegSpec {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -126,6 +130,7 @@ class DynamoDBIntegrationLoadSpec
   override def afterAll(): Unit = {
     client.shutdown()
     system.terminate()
+    super.afterAll()
   }
 
   def subscribeToRangeDeletion(probe: TestProbe): Unit =

--- a/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBIntegrationLoadSpec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBIntegrationLoadSpec.scala
@@ -95,7 +95,7 @@ my-dynamodb-journal {
   }
 
   class ProcessorCNoRecover(override val persistenceId: String, probe: ActorRef, recoverConfig: Recovery)
-      extends ProcessorC(persistenceId, probe) {
+    extends ProcessorC(persistenceId, probe) {
     override def recovery = recoverConfig
 
     override def preStart() = ()
@@ -111,12 +111,12 @@ my-dynamodb-journal {
 import DynamoDBIntegrationLoadSpec._
 
 class DynamoDBIntegrationLoadSpec
-    extends TestKit(ActorSystem("test", config))
-    with ImplicitSender
-    with WordSpecLike
-    with Matchers
-    with BeforeAndAfterAll
-    with DynamoDBUtils {
+  extends TestKit(ActorSystem("test", config))
+  with ImplicitSender
+  with WordSpecLike
+  with Matchers
+  with BeforeAndAfterAll
+  with DynamoDBUtils {
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBJournalSpec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBJournalSpec.scala
@@ -10,8 +10,9 @@ import scala.concurrent.duration._
 import akka.persistence.CapabilityFlag
 import akka.pattern.extended.ask
 import akka.actor.ActorRef
+import akka.persistence.dynamodb.IntegSpec
 
-class DynamoDBJournalSpec extends JournalSpec(ConfigFactory.load()) with DynamoDBUtils {
+class DynamoDBJournalSpec extends JournalSpec(ConfigFactory.load()) with DynamoDBUtils with IntegSpec {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -19,8 +20,8 @@ class DynamoDBJournalSpec extends JournalSpec(ConfigFactory.load()) with DynamoD
   }
 
   override def afterAll(): Unit = {
-    super.afterAll()
     client.shutdown()
+    super.afterAll()
   }
 
   override def writeMessages(fromSnr: Int, toSnr: Int, pid: String, sender: ActorRef, writerUuid: String): Unit = {

--- a/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBUtils.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBUtils.scala
@@ -3,17 +3,20 @@
  */
 package akka.persistence.dynamodb.journal
 
-import com.amazonaws.services.dynamodbv2.model._
-import scala.concurrent.Await
+import akka.persistence.dynamodb.IntegSpec
+
 import akka.actor.ActorSystem
+import akka.persistence.Persistence
+import akka.persistence.PersistentRepr
+import akka.persistence.dynamodb._
+import akka.util.Timeout
+import com.amazonaws.services.dynamodbv2.model._
+import java.util.UUID
+import scala.collection.JavaConverters._
+import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import akka.persistence.Persistence
-import akka.util.Timeout
-import java.util.UUID
-import akka.persistence.PersistentRepr
-import scala.collection.JavaConverters._
-import akka.persistence.dynamodb._
+import org.scalatest.Suite
 
 trait DynamoDBUtils {
 
@@ -25,7 +28,6 @@ trait DynamoDBUtils {
     val config = c.getConfig(c.getString("akka.persistence.journal.plugin"))
     new DynamoDBJournalConfig(config)
   }
-  import settings._
 
   lazy val client = dynamoClient(system, settings)
 
@@ -33,7 +35,7 @@ trait DynamoDBUtils {
 
   def ensureJournalTableExists(read: Long = 10L, write: Long = 10L): Unit = {
     val create = schema
-      .withTableName(JournalTable)
+      .withTableName(settings.JournalTable)
       .withProvisionedThroughput(new ProvisionedThroughput(read, write))
 
     var names = Vector.empty[String]
@@ -48,7 +50,7 @@ trait DynamoDBUtils {
     val list = client.listTables(new ListTablesRequest).flatMap(complete)
 
     val setup = for {
-      exists <- list.map(_ contains JournalTable)
+      exists <- list.map(_ contains settings.JournalTable)
       _ <- {
         if (exists) Future.successful(())
         else client.createTable(create)

--- a/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBUtils.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/DynamoDBUtils.scala
@@ -29,7 +29,7 @@ trait DynamoDBUtils {
     new DynamoDBJournalConfig(config)
   }
 
-  lazy val client = dynamoClient(system, settings)
+  lazy val client: DynamoDBHelper = dynamoClient(system, settings)
 
   implicit val timeout = Timeout(5.seconds)
 

--- a/src/test/scala/akka/persistence/dynamodb/journal/FailureReportingSpec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/FailureReportingSpec.scala
@@ -22,13 +22,13 @@ import com.typesafe.config.ConfigFactory
 import akka.persistence.dynamodb._
 
 class FailureReportingSpec extends TestKit(ActorSystem("FailureReportingSpec"))
-    with ImplicitSender
-    with WordSpecLike
-    with BeforeAndAfterAll
-    with Matchers
-    with ScalaFutures
-    with TypeCheckedTripleEquals
-    with DynamoDBUtils {
+  with ImplicitSender
+  with WordSpecLike
+  with BeforeAndAfterAll
+  with Matchers
+  with ScalaFutures
+  with TypeCheckedTripleEquals
+  with DynamoDBUtils {
 
   implicit val patience = PatienceConfig(5.seconds)
 

--- a/src/test/scala/akka/persistence/dynamodb/journal/FailureReportingSpec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/FailureReportingSpec.scala
@@ -28,7 +28,8 @@ class FailureReportingSpec extends TestKit(ActorSystem("FailureReportingSpec"))
   with Matchers
   with ScalaFutures
   with TypeCheckedTripleEquals
-  with DynamoDBUtils {
+  with DynamoDBUtils
+  with IntegSpec {
 
   implicit val patience = PatienceConfig(5.seconds)
 
@@ -50,11 +51,15 @@ class FailureReportingSpec extends TestKit(ActorSystem("FailureReportingSpec"))
     rej.cause.getMessage should include regex msg
   }
 
-  override def beforeAll(): Unit = ensureJournalTableExists()
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    ensureJournalTableExists()
+  }
 
   override def afterAll(): Unit = {
     client.shutdown()
     system.terminate().futureValue
+    super.afterAll()
   }
 
   "DynamoDB Journal Failure Reporting" must {
@@ -108,7 +113,7 @@ class FailureReportingSpec extends TestKit(ActorSystem("FailureReportingSpec"))
       val config = ConfigFactory.parseString(
         """
 dynamodb-journal {
-  endpoint = "http://localhost:8000"
+  endpoint = "http://localhost:8888"
   aws-access-key-id = "AWS_ACCESS_KEY_ID"
   aws-secret-access-key = "AWS_SECRET_ACCESS_KEY"
 }

--- a/src/test/scala/akka/persistence/dynamodb/journal/PartialAsyncSerializationSpec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/PartialAsyncSerializationSpec.scala
@@ -3,14 +3,16 @@
  */
 package akka.persistence.dynamodb.journal
 
+import akka.persistence.dynamodb.IntegSpec
+
+import akka.actor.ActorSystem
+import akka.persistence.JournalProtocol._
+import akka.persistence._
+import akka.testkit._
+import com.typesafe.config.ConfigFactory
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
-import akka.actor.ActorSystem
-import akka.persistence._
-import akka.persistence.JournalProtocol._
-import akka.testkit._
-import com.typesafe.config.ConfigFactory
 
 trait SerializeAsync
 
@@ -37,15 +39,17 @@ class PartialAsyncSerializationSpec extends TestKit(ActorSystem("PartialAsyncSer
   with Matchers
   with ScalaFutures
   with TypeCheckedTripleEquals
-  with DynamoDBUtils {
+  with DynamoDBUtils
+  with IntegSpec {
 
   override def beforeAll(): Unit = {
+    super.beforeAll()
     ensureJournalTableExists()
-
   }
   override def afterAll(): Unit = {
     client.shutdown()
     system.terminate().futureValue
+    super.afterAll()
   }
 
   override val persistenceId = "PartialAsyncSerializationSpec"

--- a/src/test/scala/akka/persistence/dynamodb/journal/PartialAsyncSerializationSpec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/PartialAsyncSerializationSpec.scala
@@ -31,13 +31,13 @@ object PartialAsyncSerializationSpec {
 }
 
 class PartialAsyncSerializationSpec extends TestKit(ActorSystem("PartialAsyncSerializationSpec", PartialAsyncSerializationSpec.config))
-    with ImplicitSender
-    with WordSpecLike
-    with BeforeAndAfterAll
-    with Matchers
-    with ScalaFutures
-    with TypeCheckedTripleEquals
-    with DynamoDBUtils {
+  with ImplicitSender
+  with WordSpecLike
+  with BeforeAndAfterAll
+  with Matchers
+  with ScalaFutures
+  with TypeCheckedTripleEquals
+  with DynamoDBUtils {
 
   override def beforeAll(): Unit = {
     ensureJournalTableExists()

--- a/src/test/scala/akka/persistence/dynamodb/journal/RecoveryConsistencySpec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/RecoveryConsistencySpec.scala
@@ -15,13 +15,13 @@ import java.util.{ HashMap => JHMap }
 import akka.persistence.dynamodb._
 
 class RecoveryConsistencySpec extends TestKit(ActorSystem("FailureReportingSpec"))
-    with ImplicitSender
-    with WordSpecLike
-    with BeforeAndAfterAll
-    with Matchers
-    with ScalaFutures
-    with TypeCheckedTripleEquals
-    with DynamoDBUtils {
+  with ImplicitSender
+  with WordSpecLike
+  with BeforeAndAfterAll
+  with Matchers
+  with ScalaFutures
+  with TypeCheckedTripleEquals
+  with DynamoDBUtils {
 
   override def beforeAll(): Unit = ensureJournalTableExists()
   override def afterAll(): Unit = {

--- a/src/test/scala/akka/persistence/dynamodb/journal/RecoveryConsistencySpec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/RecoveryConsistencySpec.scala
@@ -21,12 +21,18 @@ class RecoveryConsistencySpec extends TestKit(ActorSystem("FailureReportingSpec"
   with Matchers
   with ScalaFutures
   with TypeCheckedTripleEquals
-  with DynamoDBUtils {
+  with DynamoDBUtils
+  with IntegSpec {
 
-  override def beforeAll(): Unit = ensureJournalTableExists()
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    ensureJournalTableExists()
+  }
+
   override def afterAll(): Unit = {
     client.shutdown()
     system.terminate().futureValue
+    super.afterAll()
   }
 
   override val persistenceId = "RecoveryConsistencySpec"

--- a/src/test/scala/akka/persistence/dynamodb/snapshot/DynamoDBUtils.scala
+++ b/src/test/scala/akka/persistence/dynamodb/snapshot/DynamoDBUtils.scala
@@ -15,6 +15,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
 import org.scalatest.Suite
+import akka.persistence.dynamodb.journal.DynamoDBHelper
 
 trait DynamoDBUtils {
 
@@ -28,7 +29,7 @@ trait DynamoDBUtils {
   }
   import settings._
 
-  lazy val client = dynamoClient(system, settings)
+  lazy val client: DynamoDBHelper = dynamoClient(system, settings)
 
   implicit val timeout = Timeout(5.seconds)
 

--- a/src/test/scala/akka/persistence/dynamodb/snapshot/DynamoDBUtils.scala
+++ b/src/test/scala/akka/persistence/dynamodb/snapshot/DynamoDBUtils.scala
@@ -3,17 +3,18 @@
  */
 package akka.persistence.dynamodb.snapshot
 
-import java.util.UUID
+import akka.persistence.dynamodb.IntegSpec
+import akka.persistence.dynamodb.dynamoClient
 
 import akka.actor.ActorSystem
 import akka.persistence.PersistentRepr
 import akka.util.Timeout
 import com.amazonaws.services.dynamodbv2.model._
-
+import java.util.UUID
 import scala.collection.JavaConverters._
-import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
-import akka.persistence.dynamodb.dynamoClient
+import scala.concurrent.{ Await, Future }
+import org.scalatest.Suite
 
 trait DynamoDBUtils {
 

--- a/src/test/scala/akka/persistence/dynamodb/snapshot/SnapshotStoreTckSpec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/snapshot/SnapshotStoreTckSpec.scala
@@ -3,9 +3,11 @@
  */
 package akka.persistence.dynamodb.snapshot
 
+import akka.persistence.dynamodb.IntegSpec
+
 import akka.actor.{ ActorRef, ActorSystem }
-import akka.persistence._
 import akka.persistence.SnapshotProtocol._
+import akka.persistence._
 import akka.persistence.scalatest.OptionalTests
 import akka.persistence.snapshot.SnapshotStoreSpec
 import akka.testkit.TestProbe
@@ -13,15 +15,14 @@ import com.typesafe.config.{ Config, ConfigFactory }
 
 import scala.collection.immutable.Seq
 
-class SnapshotStoreTckSpec extends SnapshotStoreSpec(
-  ConfigFactory.load()) with DynamoDBUtils {
+class SnapshotStoreTckSpec extends SnapshotStoreSpec(ConfigFactory.load()) with DynamoDBUtils with IntegSpec {
   override def beforeAll(): Unit = {
     super.beforeAll()
     ensureSnapshotTableExists()
   }
 
   override def afterAll(): Unit = {
-    super.afterAll()
     client.shutdown()
+    super.afterAll()
   }
 }


### PR DESCRIPTION
This PR contains two features:

* move to github actions for CI. This corrects the broken travis based CI.
* use test-containers to provide a DynamoDB local container. This remove the need for developers to run DynamoDB local themselves. And enables the CI to perform these tests as well.

For an example PR that uses these checks: https://github.com/coreyoconnor/akka-persistence-dynamodb/pull/1