### PR TITLE
Use DynamoDB Query during journal replay to resolve performance issue with #106

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,24 +1,26 @@
 name := "akka-persistence-dynamodb"
 
-scalaVersion := "2.13.5"
-crossScalaVersions := Seq("2.12.13", "2.13.5")
+scalaVersion := "2.13.7"
+crossScalaVersions := Seq("2.12.15", "2.13.7")
 crossVersion := CrossVersion.binary
 
 val akkaVersion                = "2.5.29"
-val amzVersion                 = "1.11.602"
+val amzVersion                 = "1.12.125"
 val testcontainersScalaVersion = "0.39.8"
 
 libraryDependencies ++= Seq(
-  "com.amazonaws"      % "aws-java-sdk-core"              % amzVersion,
-  "com.amazonaws"      % "aws-java-sdk-dynamodb"          % amzVersion,
-  "com.typesafe.akka" %% "akka-persistence"               % akkaVersion,
-  "com.typesafe.akka" %% "akka-stream"                    % akkaVersion,
-  "com.typesafe.akka" %% "akka-persistence-tck"           % akkaVersion                % "test",
-  "com.typesafe.akka" %% "akka-testkit"                   % akkaVersion                % "test",
-  "org.scalatest"     %% "scalatest"                      % "3.0.8"                    % "test",
-  "commons-io"         % "commons-io"                     % "2.4"                      % "test",
-  "org.hdrhistogram"   % "HdrHistogram"                   % "2.1.8"                    % "test",
-  "com.dimafeng"      %% "testcontainers-scala-scalatest" % testcontainersScalaVersion % "test")
+  "com.amazonaws"           % "aws-java-sdk-core"              % amzVersion,
+  "com.amazonaws"           % "aws-java-sdk-dynamodb"          % amzVersion,
+  "com.typesafe.akka"      %% "akka-persistence"               % akkaVersion,
+  "com.typesafe.akka"      %% "akka-stream"                    % akkaVersion,
+  "org.scala-lang.modules" %% "scala-collection-compat"        % "2.6.0",
+  "com.typesafe.akka"      %% "akka-persistence-tck"           % akkaVersion                % "test",
+  "com.typesafe.akka"      %% "akka-testkit"                   % akkaVersion                % "test",
+  "com.typesafe.akka"      %% "akka-stream-testkit"            % akkaVersion                % "test",
+  "org.scalatest"          %% "scalatest"                      % "3.0.8"                    % "test",
+  "commons-io"              % "commons-io"                     % "2.4"                      % "test",
+  "org.hdrhistogram"        % "HdrHistogram"                   % "2.1.8"                    % "test",
+  "com.dimafeng"           %% "testcontainers-scala-scalatest" % testcontainersScalaVersion % "test")
 
 Test / parallelExecution := false
 // required by test-containers-scala

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.4
+sbt.version=1.6.2

--- a/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBJournal.scala
+++ b/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBJournal.scala
@@ -185,7 +185,10 @@ class DynamoDBJournal(config: Config)
   }
 
   def messagePartitionKey(persistenceId: String, sequenceNr: Long): String =
-    s"$JournalName-P-$persistenceId-${sequenceNr / 100}"
+    messagePartitionKeyFromGroupNr(persistenceId, sequenceNr / 100)
+
+  def messagePartitionKeyFromGroupNr(persistenceId: String, partitionGroupNr: Long): String =
+    s"$JournalName-P-$persistenceId-$partitionGroupNr"
 
   def highSeqKey(persistenceId: String, shard: Long) = {
     val item: Item = new JHMap

--- a/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBJournal.scala
+++ b/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBJournal.scala
@@ -180,12 +180,12 @@ class DynamoDBJournal(config: Config)
   def messageKey(persistenceId: String, sequenceNr: Long): Item = {
     val item: Item = new JHMap
     item.put(Key, S(messagePartitionKey(persistenceId, sequenceNr)))
-    item.put(Sort, N(sequenceNr % 100))
+    item.put(Sort, N(sequenceNr % PartitionSize))
     item
   }
 
   def messagePartitionKey(persistenceId: String, sequenceNr: Long): String =
-    messagePartitionKeyFromGroupNr(persistenceId, sequenceNr / 100)
+    messagePartitionKeyFromGroupNr(persistenceId, sequenceNr / PartitionSize)
 
   def messagePartitionKeyFromGroupNr(persistenceId: String, partitionGroupNr: Long): String =
     s"$JournalName-P-$persistenceId-$partitionGroupNr"

--- a/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBRecovery.scala
+++ b/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBRecovery.scala
@@ -53,7 +53,7 @@ object DynamoDBRecovery {
 case class PartitionKeys(partitionSeqNum: Long, partitionEventNums: immutable.Seq[Long])
 
 /**
- * Groups Ints from a stream into a Seq[Int] whereas each sequence shall contain the values that would be within the
+ * Groups Longs from a stream into a [PartitionKeys] whereas each sequence shall contain the values that would be within the
  * given partition size (represented by n)
  *
  * @param n - the size of partitions, this is hardcoded at 100 in other places in this library

--- a/src/main/scala/akka/persistence/dynamodb/journal/package.scala
+++ b/src/main/scala/akka/persistence/dynamodb/journal/package.scala
@@ -3,19 +3,7 @@
  */
 package akka.persistence.dynamodb
 
-import com.amazonaws.auth.BasicAWSCredentials
-import com.amazonaws.services.dynamodbv2._
 import com.amazonaws.services.dynamodbv2.model._
-import akka.actor.{ ActorSystem, Scheduler }
-import akka.event.{ Logging, LoggingAdapter }
-import java.util.{ Map => JMap }
-import scala.concurrent._
-import scala.util.{ Failure, Success, Try }
-import java.util.concurrent.{ LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit }
-import scala.collection.generic.CanBuildFrom
-import java.util.concurrent.Executors
-import java.util.Collections
-import java.nio.ByteBuffer
 
 package object journal {
 
@@ -41,7 +29,8 @@ package object journal {
 
   val KeyPayloadOverhead = 26 // including fixed parts of partition key and 36 bytes fudge factor
 
-  import collection.JavaConverters._
+  //This is the size of each partition used on DynamoDB. This value should never change as it will break backwards compatability.
+  val PartitionSize: Int = 100
 
   val schema = new CreateTableRequest()
     .withKeySchema(

--- a/src/test/scala/akka/persistence/dynamodb/journal/DynamoPartitionGroupedSpec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/DynamoPartitionGroupedSpec.scala
@@ -1,0 +1,85 @@
+package akka.persistence.dynamodb.journal
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Source
+import akka.stream.testkit.scaladsl.TestSink
+import akka.testkit.TestKit
+import org.scalatest.WordSpecLike
+
+class DynamoPartitionGroupedSpec extends TestKit(ActorSystem("DynamoPartitionGroupedSpec")) with WordSpecLike {
+  implicit val materializer = ActorMaterializer()
+
+  "A DynamoPartitionGroup should create the correct PartitionKey outputs" when {
+    "events 1 thru 250 are presented" in {
+      val sourceUnderTest =
+        Source(1L to 250).via(DynamoPartitionGrouped(100))
+
+      sourceUnderTest
+        .runWith(TestSink.probe[PartitionKeys])
+        .request(1)
+        .expectNext(PartitionKeys(0L, 1L to 99))
+        .request(1)
+        .expectNext(PartitionKeys(1L, 100L to 199))
+        .request(1)
+        .expectNext(PartitionKeys(2L, 200L to 250))
+        .expectComplete()
+    }
+
+    "events 85 through 300 are presented" in {
+      val sourceUnderTest =
+        Source(85L to 300).via(DynamoPartitionGrouped(100))
+
+      sourceUnderTest
+        .runWith(TestSink.probe[PartitionKeys])
+        .request(1)
+        .expectNext(PartitionKeys(0L, 85L to 99))
+        .request(1)
+        .expectNext(PartitionKeys(1L, 100L to 199))
+        .request(1)
+        .expectNext(PartitionKeys(2L, 200L to 299))
+        .request(1)
+        .expectNext(PartitionKeys(3L, scala.collection.immutable.Seq(300L)))
+        .expectComplete()
+    }
+
+    "events 185 through 512 are presented" in {
+      val sourceUnderTest =
+        Source(185L to 512).via(DynamoPartitionGrouped(100))
+
+      sourceUnderTest
+        .runWith(TestSink.probe[PartitionKeys])
+        .request(1)
+        .expectNext(PartitionKeys(1L, 185L to 199))
+        .request(3)
+        .expectNext(PartitionKeys(2L, 200L to 299), PartitionKeys(3L, 300L to 399), PartitionKeys(4L, 400L to 499))
+        .request(1)
+        .expectNext(PartitionKeys(5L, 500L to 512))
+        .expectComplete()
+    }
+  }
+
+  "A DynamoPartitionGroup should complete when source is exhausted" when {
+    "should complete with correct partition from events 1 through 15" in {
+      val sourceUnderTest =
+        Source(1L to 15).via(DynamoPartitionGrouped(100))
+
+      sourceUnderTest
+        .runWith(TestSink.probe[PartitionKeys])
+        .request(2)
+        .expectNext(PartitionKeys(0L, 1L to 15))
+        .expectComplete()
+    }
+
+    "should complete with correct partition keys when events 1 through 99 are presented and source ends" in {
+      val sourceUnderTest =
+        Source(1L to 99).via(DynamoPartitionGrouped(100))
+
+      sourceUnderTest
+        .runWith(TestSink.probe[PartitionKeys])
+        .request(2)
+        .expectNext(PartitionKeys(0L, 1L to 99))
+        .expectComplete()
+    }
+  }
+}

--- a/src/test/scala/akka/persistence/dynamodb/journal/DynamoPartitionGroupedSpec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/DynamoPartitionGroupedSpec.scala
@@ -13,7 +13,7 @@ class DynamoPartitionGroupedSpec extends TestKit(ActorSystem("DynamoPartitionGro
   "A DynamoPartitionGroup should create the correct PartitionKey outputs" when {
     "events 1 thru 250 are presented" in {
       val sourceUnderTest =
-        Source(1L to 250).via(DynamoPartitionGrouped(100))
+        Source(1L to 250).via(DynamoPartitionGrouped)
 
       sourceUnderTest
         .runWith(TestSink.probe[PartitionKeys])
@@ -28,7 +28,7 @@ class DynamoPartitionGroupedSpec extends TestKit(ActorSystem("DynamoPartitionGro
 
     "events 85 through 300 are presented" in {
       val sourceUnderTest =
-        Source(85L to 300).via(DynamoPartitionGrouped(100))
+        Source(85L to 300).via(DynamoPartitionGrouped)
 
       sourceUnderTest
         .runWith(TestSink.probe[PartitionKeys])
@@ -45,7 +45,7 @@ class DynamoPartitionGroupedSpec extends TestKit(ActorSystem("DynamoPartitionGro
 
     "events 185 through 512 are presented" in {
       val sourceUnderTest =
-        Source(185L to 512).via(DynamoPartitionGrouped(100))
+        Source(185L to 512).via(DynamoPartitionGrouped)
 
       sourceUnderTest
         .runWith(TestSink.probe[PartitionKeys])
@@ -62,7 +62,7 @@ class DynamoPartitionGroupedSpec extends TestKit(ActorSystem("DynamoPartitionGro
   "A DynamoPartitionGroup should complete when source is exhausted" when {
     "should complete with correct partition from events 1 through 15" in {
       val sourceUnderTest =
-        Source(1L to 15).via(DynamoPartitionGrouped(100))
+        Source(1L to 15).via(DynamoPartitionGrouped)
 
       sourceUnderTest
         .runWith(TestSink.probe[PartitionKeys])
@@ -73,7 +73,7 @@ class DynamoPartitionGroupedSpec extends TestKit(ActorSystem("DynamoPartitionGro
 
     "should complete with correct partition keys when events 1 through 99 are presented and source ends" in {
       val sourceUnderTest =
-        Source(1L to 99).via(DynamoPartitionGrouped(100))
+        Source(1L to 99).via(DynamoPartitionGrouped)
 
       sourceUnderTest
         .runWith(TestSink.probe[PartitionKeys])


### PR DESCRIPTION
Use DynamoDB Query during journal replay to resolve performance issue with #106

* Use DynamoDB Query during replay instead of BatchGetItem. This involved building up a custom Akka Streams graph stage so we can group sequence numbers per Dynamo partition, previous implementation required use of batch get item as items emitted by akka streams grouped flow would commonly produce items to be fetched that would span more than one partition key on Dynamodb.
* Added tests to verify new GraphStage emits the proper partition groupings such that the Dynamo Query operation will work as expected.
* Bumped scala versions for 2.12 and 2.13, bumped AWS version
* removed the need for getReplayBatch at all - we should always use DynamoDB query whenever replaying events on the journal.

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #106 
