### PR TITLE
Avoid creating materializers

### DIFF
--- a/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBJournal.scala
+++ b/src/main/scala/akka/persistence/dynamodb/journal/DynamoDBJournal.scala
@@ -13,7 +13,7 @@ import akka.pattern.pipe
 import akka.persistence.journal.AsyncWriteJournal
 import akka.persistence.{ AtomicWrite, Persistence, PersistentRepr }
 import akka.serialization.{ AsyncSerializer, SerializationExtension }
-import akka.stream.ActorMaterializer
+import akka.stream.{ Materializer, SystemMaterializer }
 import akka.util.ByteString
 import com.amazonaws.AmazonServiceException
 import com.amazonaws.auth.BasicAWSCredentials
@@ -78,7 +78,7 @@ class DynamoDBJournal(config: Config)
     with ActorLogging {
   import context.dispatcher
 
-  implicit val materializer = ActorMaterializer()
+  implicit val materializer: Materializer = SystemMaterializer(context.system).materializer
 
   val extension     = Persistence(context.system)
   val serialization = SerializationExtension(context.system)

--- a/src/test/scala/akka/persistence/dynamodb/journal/DynamoPartitionGroupedSpec.scala
+++ b/src/test/scala/akka/persistence/dynamodb/journal/DynamoPartitionGroupedSpec.scala
@@ -1,14 +1,14 @@
 package akka.persistence.dynamodb.journal
 
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
+import akka.stream.{ActorMaterializer, Materializer, SystemMaterializer}
 import akka.stream.scaladsl.Source
 import akka.stream.testkit.scaladsl.TestSink
 import akka.testkit.TestKit
 import org.scalatest.WordSpecLike
 
 class DynamoPartitionGroupedSpec extends TestKit(ActorSystem("DynamoPartitionGroupedSpec")) with WordSpecLike {
-  implicit val materializer = ActorMaterializer()
+  implicit val materializer: Materializer = SystemMaterializer(system).materializer
 
   assert(PartitionSize == 100, "This test is only valid with PartitionSize == 100")
 


### PR DESCRIPTION
In Akka 2.6 creating materializes is no longer advisable. Compare for instance [this PR](https://github.com/akka/akka-persistence-jdbc/pull/470) for the jdbc implementation.
