### PR TITLE
chore: renamed github repo akka-persistence-dynamodb-1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ v 1.1.2 (v 1.2.0)
 
 This was supposed to be released as `v1.2.0` but was released as `v1.1.2` to maven. Sorry about that!
 
-* Use DynamoDB Query during journal replay - https://github.com/akka/akka-persistence-dynamodb/issues/106
-* Correct issue [#98](https://github.com/akka/akka-persistence-dynamodb/issues/98)
+* Use DynamoDB Query during journal replay - https://github.com/akka/akka-persistence-dynamodb-1.x/issues/106
+* Correct issue [#98](https://github.com/akka/akka-persistence-dynamodb-1.x/issues/98)
   Please see [fixes in `reference.conf`](blob/master/src/main/resources/reference.conf) for a workaround for systems impacted by this issues.
 * Depends on Akka 2.5.
 * Adds Support for the Async Serializers - which enables the use of the plugin with Lightbend extensions [GDPR Addons](https://developer.lightbend.com/docs/akka-commercial-addons/current/gdpr/index.html)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,7 @@
 ## Infrastructure
 
 * [Typesafe Contributor License Agreement](http://www.typesafe.com/contribute/cla)
-* [Issue Tracker](https://github.com/akka/akka-persistence-dynamodb/issues)
-* [Travis CI](https://travis-ci.org/akka/akka-persistence-dynamodb)
+* [Issue Tracker](https://github.com/akka/akka-persistence-dynamodb-1.x/issues)
 
 # Typesafe Project & Developer Guidelines
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 DynamoDBJournal for Akka Persistence
 ====================================
 
+**Version 2.x of the DynamoDB plugin is developed and maintained in https://github.com/akka/akka-persistence-dynamodb.**
+
 A replicated [Akka Persistence](http://doc.akka.io/docs/akka/2.4.0/scala/persistence.html) journal backed by
 [Amazon DynamoDB](http://aws.amazon.com/dynamodb/).
 
@@ -51,7 +53,7 @@ my-dynamodb-journal {                     # and add some overrides
 }
 ~~~
 
-For details on the endpoint URL please refer to the [DynamoDB documentation](http://docs.aws.amazon.com/general/latest/gr/rande.html#ddb_region). There are many more settings that can be used for fine-tuning and adapting this journal plugin to your use-case, please refer to the [reference.conf](https://github.com/akka/akka-persistence-dynamodb/blob/master/src/main/resources/reference.conf) file.
+For details on the endpoint URL please refer to the [DynamoDB documentation](http://docs.aws.amazon.com/general/latest/gr/rande.html#ddb_region). There are many more settings that can be used for fine-tuning and adapting this journal plugin to your use-case, please refer to the [reference.conf](https://github.com/akka/akka-persistence-dynamodb-1.x/blob/master/src/main/resources/reference.conf) file.
 
 Before you can use these settings you will have to create a table, e.g. using the AWS console, with the following schema:
 
@@ -226,4 +228,5 @@ Credits
 Support
 -------
 
-This project is *community maintained*. The Lightbend subscription does not cover support for this project.
+The 1.x version of this project is *not maintained*. The Lightbend subscription does not cover support for this project.
+Version 2.x of the DynamoDB plugin is developed and maintained in https://github.com/akka/akka-persistence-dynamodb.

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -24,7 +24,7 @@ object Publish extends AutoPlugin {
     organizationName := "Typesafe Inc.",
     organizationHomepage := Some(url("http://www.typesafe.com")),
     licenses := Seq(("Apache License, Version 2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))),
-    homepage := Some(url("https://github.com/akka/akka-persistence-dynamodb")),
+    homepage := Some(url("https://github.com/akka/akka-persistence-dynamodb-1.x")),
     publishMavenStyle := true,
     pomIncludeRepository := { x => false },
     defaultPublishTo := crossTarget.value / "repository")
@@ -35,7 +35,7 @@ object Publish extends AutoPlugin {
         <id>contributors</id>
         <name>Contributors</name>
         <email>akka-dev@googlegroups.com</email>
-        <url>https://github.com/akka/akka-persistence-dynamodb/graphs/contributors</url>
+        <url>https://github.com/akka/akka-persistence-dynamodb-1.x/graphs/contributors</url>
       </developer>
     </developers>
   }


### PR DESCRIPTION
FYI @joost-de-vries, @coreyoconnor, @rmmeans This github repository has been renamed to akka-persistence-dynamodb-1.x and we intend to archive it. We have developed a completely new DynamoDB plugin, which is now in https://github.com/akka/akka-persistence-dynamodb